### PR TITLE
Try without identifying current user

### DIFF
--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -684,7 +684,7 @@ static void fill_own_user() {
 
 	pw = getpwuid(uid);
 	if (pw == NULL || pw->pw_name == NULL) {
-		dropbear_exit("Unknown own user");
+		dropbear_log(LOG_INFO, "Warning: failed to identify current user. Trying anyway.");
 	}
 
 	cli_opts.own_user = m_strdup(pw->pw_name);


### PR DESCRIPTION
Small change that warns the user if the current user cannot be identified rather than aborting.  This came in handy when I put dropbear on a dlink that did not have a true user environment.  Falling back on the "-l" option and user@ options works just fine as a client.  The only implication I found is that the -J option will fail ungracefully without a known own_user.
