### PR TITLE
Fix installing dropbear.8 error when building in a separate directory.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -131,7 +131,7 @@ insmultidropbear: dropbearmulti
 	-rm -f $(DESTDIR)$(sbindir)/dropbear$(EXEEXT)
 	-ln -s $(bindir)/dropbearmulti$(EXEEXT) $(DESTDIR)$(sbindir)/dropbear$(EXEEXT) 
 	$(INSTALL) -d $(DESTDIR)$(mandir)/man8
-	$(INSTALL) -m 644 dropbear.8  $(DESTDIR)$(mandir)/man8/dropbear.8
+	$(INSTALL) -m 644 $(srcdir)/dropbear.8  $(DESTDIR)$(mandir)/man8/dropbear.8
 
 insmulti%: dropbearmulti
 	$(INSTALL) -d $(DESTDIR)$(bindir)
@@ -145,7 +145,7 @@ inst_dropbear: dropbear
 	$(INSTALL) -d $(DESTDIR)$(sbindir)
 	$(INSTALL) dropbear$(EXEEXT) $(DESTDIR)$(sbindir)
 	$(INSTALL) -d $(DESTDIR)$(mandir)/man8
-	$(INSTALL) -m 644 dropbear.8 $(DESTDIR)$(mandir)/man8/dropbear.8
+	$(INSTALL) -m 644 $(srcdir)/dropbear.8 $(DESTDIR)$(mandir)/man8/dropbear.8
 
 inst_%: %
 	$(INSTALL) -d $(DESTDIR)$(bindir)


### PR DESCRIPTION
When building dropbear in a separate directory, 

make install 

will failed to install dropbear.8

Fix it by prepending $(srcdir) to dropbear.8 