### PR TITLE
Fix variables may be uninitialized.

### DIFF
--- a/keyimport.c
+++ b/keyimport.c
@@ -627,7 +627,7 @@ static sign_key *openssh_read(const char *filename, char * UNUSED(passphrase))
 
 		if (i == 0) {
 			/* First integer is a version indicator */
-			int expected;
+			int expected = -1;
 			switch (key->type) {
 				case OSSH_RSA:
 				case OSSH_DSA:
@@ -826,7 +826,7 @@ static int openssh_write(const char *filename, sign_key *key,
 	unsigned char *outblob = NULL;
 	int outlen = -9999;
 	struct mpint_pos numbers[9];
-	int nnumbers = -1, pos, len, seqlen, i;
+	int nnumbers = -1, pos = 0, len = 0, seqlen, i;
 	char *header = NULL, *footer = NULL;
 	char zero[1];
 	int ret = 0;


### PR DESCRIPTION
When building dropbear by GCC 4.8.2 in Ubuntu 14.04 amd64, it reported

```
gcc -I../dropbear/libtomcrypt/src/headers/ -I. -I../dropbear  -Os -W -Wall -Wno-pointer-sign -DDROPBEAR_SERVER -DDROPBEAR_CLIENT   -c -o keyimport.o ../dropbear/keyimport.c
../dropbear/keyimport.c: In function ‘openssh_write’:
../dropbear/keyimport.c:1137:10: warning: ‘len’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  dropbear_assert(pos == len);
          ^
../dropbear/keyimport.c:829:26: note: ‘len’ was declared here
  int nnumbers = -1, pos, len, seqlen, i;
                          ^
../dropbear/keyimport.c:1137:10: warning: ‘pos’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  dropbear_assert(pos == len);
          ^
../dropbear/keyimport.c:829:21: note: ‘pos’ was declared here
  int nnumbers = -1, pos, len, seqlen, i;
                     ^
../dropbear/keyimport.c: In function ‘import_read’:
../dropbear/keyimport.c:640:17: warning: ‘expected’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    if (len != 1 || p[0] != expected) {
                 ^
../dropbear/keyimport.c:630:8: note: ‘expected’ was declared here
    int expected;
        ^
```