### PR TITLE
Prefer stronger algorithms in algorithm negotiation.

### DIFF
--- a/cli-agentfwd.c
+++ b/cli-agentfwd.c
@@ -210,7 +210,7 @@ static void agent_get_key_list(m_list * ret_list)
 		ret = buf_get_pub_key(key_buf, pubkey, &key_type);
 		buf_free(key_buf);
 		if (ret != DROPBEAR_SUCCESS) {
-			TRACE(("Skipping bad pubkey from agent"));
+			TRACE(("Skipping bad/unknown type pubkey from agent"));
 			sign_key_free(pubkey);
 		} else {
 			pubkey->type = key_type;

--- a/cli-agentfwd.c
+++ b/cli-agentfwd.c
@@ -210,13 +210,14 @@ static void agent_get_key_list(m_list * ret_list)
 		ret = buf_get_pub_key(key_buf, pubkey, &key_type);
 		buf_free(key_buf);
 		if (ret != DROPBEAR_SUCCESS) {
-			/* This is slack, properly would cleanup vars etc */
-			dropbear_exit("Bad pubkey received from agent");
-		}
-		pubkey->type = key_type;
-		pubkey->source = SIGNKEY_SOURCE_AGENT;
+			TRACE(("Skipping bad pubkey from agent"));
+			sign_key_free(pubkey);
+		} else {
+			pubkey->type = key_type;
+			pubkey->source = SIGNKEY_SOURCE_AGENT;
 
-		list_append(ret_list, pubkey);
+			list_append(ret_list, pubkey);
+		}
 
 		/* We'll ignore the comment for now. might want it later.*/
 		buf_eatstring(inbuf);

--- a/common-algo.c
+++ b/common-algo.c
@@ -137,9 +137,6 @@ algo_type sshciphers[] = {
 #ifdef DROPBEAR_AES128
 	{"aes128-ctr", 0, &dropbear_aes128, 1, &dropbear_mode_ctr},
 #endif
-#ifdef DROPBEAR_3DES
-	{"3des-ctr", 0, &dropbear_3des, 1, &dropbear_mode_ctr},
-#endif
 #ifdef DROPBEAR_AES256
 	{"aes256-ctr", 0, &dropbear_aes256, 1, &dropbear_mode_ctr},
 #endif
@@ -148,9 +145,6 @@ algo_type sshciphers[] = {
 /* CBC modes are always enabled */
 #ifdef DROPBEAR_AES128
 	{"aes128-cbc", 0, &dropbear_aes128, 1, &dropbear_mode_cbc},
-#endif
-#ifdef DROPBEAR_3DES
-	{"3des-cbc", 0, &dropbear_3des, 1, &dropbear_mode_cbc},
 #endif
 #ifdef DROPBEAR_AES256
 	{"aes256-cbc", 0, &dropbear_aes256, 1, &dropbear_mode_cbc},
@@ -161,6 +155,12 @@ algo_type sshciphers[] = {
 #endif
 #ifdef DROPBEAR_TWOFISH128
 	{"twofish128-cbc", 0, &dropbear_twofish128, 1, &dropbear_mode_cbc},
+#endif
+#ifdef DROPBEAR_3DES
+	{"3des-ctr", 0, &dropbear_3des, 1, &dropbear_mode_ctr},
+#endif
+#ifdef DROPBEAR_3DES
+	{"3des-cbc", 0, &dropbear_3des, 1, &dropbear_mode_cbc},
 #endif
 #ifdef DROPBEAR_BLOWFISH
 	{"blowfish-cbc", 0, &dropbear_blowfish, 1, &dropbear_mode_cbc},
@@ -195,8 +195,8 @@ algo_type sshhashes[] = {
 
 #ifndef DISABLE_ZLIB
 algo_type ssh_compress[] = {
-	{"zlib", DROPBEAR_COMP_ZLIB, NULL, 1, NULL},
 	{"zlib@openssh.com", DROPBEAR_COMP_ZLIB_DELAY, NULL, 1, NULL},
+	{"zlib", DROPBEAR_COMP_ZLIB, NULL, 1, NULL},
 	{"none", DROPBEAR_COMP_NONE, NULL, 1, NULL},
 	{NULL, 0, NULL, 0, NULL}
 };
@@ -265,8 +265,8 @@ algo_type sshkex[] = {
 	{"ecdh-sha2-nistp256", 0, &kex_ecdh_nistp256, 1, NULL},
 #endif
 #endif
-	{"diffie-hellman-group1-sha1", 0, &kex_dh_group1, 1, NULL},
 	{"diffie-hellman-group14-sha1", 0, &kex_dh_group14, 1, NULL},
+	{"diffie-hellman-group1-sha1", 0, &kex_dh_group1, 1, NULL},
 #ifdef USE_KEXGUESS2
 	{KEXGUESS2_ALGO_NAME, KEXGUESS2_ALGO_ID, NULL, 1, NULL},
 #endif


### PR DESCRIPTION
Prefer diffie-hellman-group14-sha1 (2048 bit) over
 diffie-hellman-group1-sha1 (1024 bit).

Due to meet-in-the-middle attacks the effective key length of
three key 3DES is 112 bits. AES is stronger and faster then 3DES.

Prefer to delay the start of compression until after authentication
has completed. This avoids exposing compression code to attacks
from unauthenticated users.