### PR TITLE
allow rm -rf libtomcrypt libtommath when building with system libtom*

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -660,6 +660,7 @@ fi
 AC_EXEEXT
 
 # XXX there must be a nicer way to do this
+if test $BUNDLED_LIBTOM = 1 ; then
 AS_MKDIR_P(libtomcrypt/src/ciphers/aes)
 AS_MKDIR_P(libtomcrypt/src/ciphers/safer)
 AS_MKDIR_P(libtomcrypt/src/ciphers/twofish)
@@ -710,8 +711,10 @@ AS_MKDIR_P(libtomcrypt/src/pk/katja)
 AS_MKDIR_P(libtomcrypt/src/pk/pkcs1)
 AS_MKDIR_P(libtomcrypt/src/pk/rsa)
 AS_MKDIR_P(libtomcrypt/src/prngs)
+LIBTOM_FILES="libtomcrypt/Makefile libtommath/Makefile"
+fi
 AC_CONFIG_HEADER(config.h)
-AC_CONFIG_FILES(Makefile libtomcrypt/Makefile libtommath/Makefile)
+AC_CONFIG_FILES(Makefile $LIBTOM_FILES)
 AC_OUTPUT
 
 AC_MSG_NOTICE()


### PR DESCRIPTION
this allows better to ensure system lib is used. useful for linux distributions