### PR TITLE
Fix scp build failure if _PATH_SSH_PROGRAM is unset

### DIFF
--- a/options.h
+++ b/options.h
@@ -290,6 +290,9 @@ much traffic. */
 /* This is used by the scp binary when used as a client binary. If you're
  * not using the Dropbear client, you'll need to change it */
 #define DROPBEAR_PATH_SSH_PROGRAM "/usr/bin/dbclient"
+#ifndef _PATH_SSH_PROGRAM
+#define _PATH_SSH_PROGRAM DROPBEAR_PATH_SSH_PROGRAM
+#endif
 
 /* Whether to log commands executed by a client. This only logs the 
  * (single) command sent to the server, not what a user did in a 


### PR DESCRIPTION
Hi,

This patch fix the build for scp (see error below).

The build failure has been introduced by commit fdb7ffa864dea8e1c9efe3532db08b1ccad484dc that renames the definition of *_PATH_SSH_PROGRAM* to *POLARSSL_PATH_SSH_PROGRAM*.
As a consequence, *_PATH_SSH_PROGRAM* is not defined anymore and leads to a compilation error.

This patch defines *_PATH_SSH_PROGRAM* to *POLARSSL_PATH_SSH_PROGRAM* if it is unset.

```
gcc -I../libtomcrypt/src/headers/ -I. -I..  -Os -W -Wall -Wno-pointer-sign -DDROPBEAR_SERVER -DDROPBEAR_CLIENT   -c -o scp.o ../scp.c
../scp.c:99:21: error: ‘_PATH_SSH_PROGRAM’ undeclared here (not in a function)
 char *ssh_program = _PATH_SSH_PROGRAM;
```