### PR TITLE
Fix warnings

### DIFF
--- a/algo.h
+++ b/algo.h
@@ -35,7 +35,7 @@
 
 struct Algo_Type {
 
-	const unsigned char *name; /* identifying name */
+	const char *name; /* identifying name */
 	char val; /* a value for this cipher, or -1 for invalid */
 	const void *data; /* algorithm specific data */
 	char usable; /* whether we can use this algorithm */

--- a/auth.h
+++ b/auth.h
@@ -133,7 +133,7 @@ struct PubKeyOptions {
 	int no_x11_forwarding_flag;
 	int no_pty_flag;
 	/* "command=" option. */
-	unsigned char * forced_command;
+	char * forced_command;
 };
 #endif
 

--- a/channel.h
+++ b/channel.h
@@ -135,7 +135,7 @@ int send_msg_channel_open_init(int fd, const struct ChanType *type);
 void recv_msg_channel_open_confirmation();
 void recv_msg_channel_open_failure();
 #endif
-void start_send_channel_request(struct Channel *channel, unsigned char *type);
+void start_send_channel_request(struct Channel *channel, char *type);
 
 void send_msg_request_success();
 void send_msg_request_failure();

--- a/chansession.h
+++ b/chansession.h
@@ -39,14 +39,14 @@ struct exitinfo {
 
 struct ChanSess {
 
-	unsigned char * cmd; /* command to exec */
+	char * cmd; /* command to exec */
 	pid_t pid; /* child process pid */
 
 	/* pty details */
 	int master; /* the master terminal fd*/
 	int slave;
-	unsigned char * tty;
-	unsigned char * term;
+	char * tty;
+	char * term;
 
 	/* exit details */
 	struct exitinfo exit;

--- a/cli-auth.c
+++ b/cli-auth.c
@@ -43,11 +43,11 @@ void cli_auth_getmethods() {
 	TRACE(("enter cli_auth_getmethods"))
 	CHECKCLEARTOWRITE();
 	buf_putbyte(ses.writepayload, SSH_MSG_USERAUTH_REQUEST);
-	buf_putstring(ses.writepayload, cli_opts.username, 
+	buf_putstring(ses.writepayload, (const unsigned char *)cli_opts.username,
 			strlen(cli_opts.username));
-	buf_putstring(ses.writepayload, SSH_SERVICE_CONNECTION, 
+	buf_putstring(ses.writepayload, (const unsigned char *)SSH_SERVICE_CONNECTION,
 			SSH_SERVICE_CONNECTION_LEN);
-	buf_putstring(ses.writepayload, "none", 4); /* 'none' method */
+	buf_putstring(ses.writepayload, (const unsigned char *)"none", 4); /* 'none' method */
 
 	encrypt_packet();
 
@@ -75,7 +75,7 @@ void cli_auth_getmethods() {
 
 void recv_msg_userauth_banner() {
 
-	unsigned char* banner = NULL;
+	char* banner = NULL;
 	unsigned int bannerlen;
 	unsigned int i, linecount;
 
@@ -85,7 +85,7 @@ void recv_msg_userauth_banner() {
 		return;
 	}
 
-	banner = buf_getstring(ses.payload, &bannerlen);
+	banner = (char *)buf_getstring(ses.payload, &bannerlen);
 	buf_eatstring(ses.payload); /* The language string */
 
 	if (bannerlen > MAX_BANNER_SIZE) {
@@ -151,8 +151,8 @@ void recv_msg_userauth_specific_60() {
 
 void recv_msg_userauth_failure() {
 
-	unsigned char * methods = NULL;
-	unsigned char * tok = NULL;
+	char * methods = NULL;
+	char * tok = NULL;
 	unsigned int methlen = 0;
 	unsigned int partial = 0;
 	unsigned int i = 0;
@@ -201,7 +201,7 @@ void recv_msg_userauth_failure() {
 		cli_ses.lastauthtype = AUTH_TYPE_NONE;
 	}
 
-	methods = buf_getstring(ses.payload, &methlen);
+	methods = (char *)buf_getstring(ses.payload, &methlen);
 
 	partial = buf_getbool(ses.payload);
 

--- a/cli-authinteract.c
+++ b/cli-authinteract.c
@@ -31,10 +31,10 @@
 
 #ifdef ENABLE_CLI_INTERACT_AUTH
 
-static unsigned char* get_response(unsigned char* prompt)
+static char* get_response(char* prompt)
 {
 	FILE* tty = NULL;
-	unsigned char* response = NULL;
+	char* response = NULL;
 	/* not a password, but a reasonable limit */
 	char buf[DROPBEAR_MAX_CLI_PASS];
 	char* ret = NULL;
@@ -50,13 +50,13 @@ static unsigned char* get_response(unsigned char* prompt)
 	}
 
 	if (ret == NULL) {
-		response = (unsigned char*)m_strdup("");
+		response = m_strdup("");
 	} else {
 		unsigned int buflen = strlen(buf);
 		/* fgets includes newlines */
 		if (buflen > 0 && buf[buflen-1] == '\n')
 			buf[buflen-1] = '\0';
-		response = (unsigned char*)m_strdup(buf);
+		response = m_strdup(buf);
 	}
 
 	m_burn(buf, sizeof(buf));
@@ -66,14 +66,14 @@ static unsigned char* get_response(unsigned char* prompt)
 
 void recv_msg_userauth_info_request() {
 
-	unsigned char *name = NULL;
-	unsigned char *instruction = NULL;
+	char *name = NULL;
+	char *instruction = NULL;
 	unsigned int num_prompts = 0;
 	unsigned int i;
 
-	unsigned char *prompt = NULL;
+	char *prompt = NULL;
 	unsigned int echo = 0;
-	unsigned char *response = NULL;
+	char *response = NULL;
 
 	TRACE(("enter recv_msg_recv_userauth_info_request"))
 
@@ -84,8 +84,8 @@ void recv_msg_userauth_info_request() {
 	}
 	cli_ses.interact_request_received = 1;
 
-	name = buf_getstring(ses.payload, NULL);
-	instruction = buf_getstring(ses.payload, NULL);
+	name = (char *)buf_getstring(ses.payload, NULL);
+	instruction = (char *)buf_getstring(ses.payload, NULL);
 
 	/* language tag */
 	buf_eatstring(ses.payload);
@@ -115,13 +115,13 @@ void recv_msg_userauth_info_request() {
 
 	for (i = 0; i < num_prompts; i++) {
 		unsigned int response_len = 0;
-		prompt = buf_getstring(ses.payload, NULL);
+		prompt = (char *)buf_getstring(ses.payload, NULL);
 		cleantext(prompt);
 
 		echo = buf_getbool(ses.payload);
 
 		if (!echo) {
-			unsigned char* p = getpass_or_cancel(prompt);
+			char* p = getpass_or_cancel(prompt);
 			response = m_strdup(p);
 			m_burn(p, strlen(p));
 		} else {
@@ -129,7 +129,7 @@ void recv_msg_userauth_info_request() {
 		}
 
 		response_len = strlen(response);
-		buf_putstring(ses.writepayload, response, response_len);
+		buf_putstring(ses.writepayload, (const unsigned char *)response, response_len);
 		m_burn(response, response_len);
 		m_free(prompt);
 		m_free(response);
@@ -149,22 +149,22 @@ void cli_auth_interactive() {
 	buf_putbyte(ses.writepayload, SSH_MSG_USERAUTH_REQUEST);
 
 	/* username */
-	buf_putstring(ses.writepayload, cli_opts.username,
+	buf_putstring(ses.writepayload, (const unsigned char *)cli_opts.username,
 			strlen(cli_opts.username));
 
 	/* service name */
-	buf_putstring(ses.writepayload, SSH_SERVICE_CONNECTION, 
+	buf_putstring(ses.writepayload, (const unsigned char *)SSH_SERVICE_CONNECTION,
 			SSH_SERVICE_CONNECTION_LEN);
 
 	/* method */
-	buf_putstring(ses.writepayload, AUTH_METHOD_INTERACT,
+	buf_putstring(ses.writepayload, (const unsigned char *)AUTH_METHOD_INTERACT,
 			AUTH_METHOD_INTERACT_LEN);
 
 	/* empty language tag */
-	buf_putstring(ses.writepayload, "", 0);
+	buf_putstring(ses.writepayload, (const unsigned char *)"", 0);
 
 	/* empty submethods */
-	buf_putstring(ses.writepayload, "", 0);
+	buf_putstring(ses.writepayload, (const unsigned char *)"", 0);
 
 	encrypt_packet();
 	cli_ses.interact_request_received = 0;

--- a/cli-authpasswd.c
+++ b/cli-authpasswd.c
@@ -140,18 +140,18 @@ void cli_auth_password() {
 
 	buf_putbyte(ses.writepayload, SSH_MSG_USERAUTH_REQUEST);
 
-	buf_putstring(ses.writepayload, cli_opts.username,
+	buf_putstring(ses.writepayload, (const unsigned char *)cli_opts.username,
 			strlen(cli_opts.username));
 
-	buf_putstring(ses.writepayload, SSH_SERVICE_CONNECTION, 
+	buf_putstring(ses.writepayload, (const unsigned char *)SSH_SERVICE_CONNECTION,
 			SSH_SERVICE_CONNECTION_LEN);
 
-	buf_putstring(ses.writepayload, AUTH_METHOD_PASSWORD, 
+	buf_putstring(ses.writepayload, (const unsigned char *)AUTH_METHOD_PASSWORD,
 			AUTH_METHOD_PASSWORD_LEN);
 
 	buf_putbyte(ses.writepayload, 0); /* FALSE - so says the spec */
 
-	buf_putstring(ses.writepayload, password, strlen(password));
+	buf_putstring(ses.writepayload, (const unsigned char *)password, strlen(password));
 
 	encrypt_packet();
 	m_burn(password, strlen(password));

--- a/cli-authpubkey.c
+++ b/cli-authpubkey.c
@@ -63,7 +63,7 @@ void recv_msg_userauth_pk_ok() {
 
 	TRACE(("enter recv_msg_userauth_pk_ok"))
 
-	algotype = buf_getstring(ses.payload, &algolen);
+	algotype = (char *)buf_getstring(ses.payload, &algolen);
 	keytype = signkey_type_from_name(algotype, algolen);
 	TRACE(("recv_msg_userauth_pk_ok: type %d", keytype))
 	m_free(algotype);
@@ -141,7 +141,7 @@ void cli_buf_put_sign(buffer* buf, sign_key *key, int type,
 static void send_msg_userauth_pubkey(sign_key *key, int type, int realsign) {
 
 	const char *algoname = NULL;
-	int algolen;
+	unsigned int algolen;
 	buffer* sigbuf = NULL;
 
 	TRACE(("enter send_msg_userauth_pubkey"))
@@ -149,20 +149,20 @@ static void send_msg_userauth_pubkey(sign_key *key, int type, int realsign) {
 
 	buf_putbyte(ses.writepayload, SSH_MSG_USERAUTH_REQUEST);
 
-	buf_putstring(ses.writepayload, cli_opts.username,
+	buf_putstring(ses.writepayload, (const unsigned char *)cli_opts.username,
 			strlen(cli_opts.username));
 
-	buf_putstring(ses.writepayload, SSH_SERVICE_CONNECTION, 
+	buf_putstring(ses.writepayload, (const unsigned char *)SSH_SERVICE_CONNECTION,
 			SSH_SERVICE_CONNECTION_LEN);
 
-	buf_putstring(ses.writepayload, AUTH_METHOD_PUBKEY, 
+	buf_putstring(ses.writepayload, (const unsigned char *)AUTH_METHOD_PUBKEY,
 			AUTH_METHOD_PUBKEY_LEN);
 
 	buf_putbyte(ses.writepayload, realsign);
 
 	algoname = signkey_name_from_type(type, &algolen);
 
-	buf_putstring(ses.writepayload, algoname, algolen);
+	buf_putstring(ses.writepayload, (const unsigned char *)algoname, algolen);
 	buf_put_pub_key(ses.writepayload, key, type);
 
 	if (realsign) {

--- a/cli-chansession.c
+++ b/cli-chansession.c
@@ -56,12 +56,12 @@ const struct ChanType clichansess = {
 
 static void cli_chansessreq(struct Channel *channel) {
 
-	unsigned char* type = NULL;
+	char* type = NULL;
 	int wantreply;
 
 	TRACE(("enter cli_chansessreq"))
 
-	type = buf_getstring(ses.payload, NULL);
+	type = (char *) buf_getstring(ses.payload, NULL);
 	wantreply = buf_getbool(ses.payload);
 
 	if (strcmp(type, "exit-status") == 0) {
@@ -261,7 +261,7 @@ void cli_chansess_winchange() {
 			CHECKCLEARTOWRITE();
 			buf_putbyte(ses.writepayload, SSH_MSG_CHANNEL_REQUEST);
 			buf_putint(ses.writepayload, channel->remotechan);
-			buf_putstring(ses.writepayload, "window-change", 13);
+			buf_putstring(ses.writepayload, (const unsigned char *) "window-change", 13);
 			buf_putbyte(ses.writepayload, 0); /* FALSE says the spec */
 			put_winsize();
 			encrypt_packet();
@@ -272,7 +272,7 @@ void cli_chansess_winchange() {
 
 static void send_chansess_pty_req(struct Channel *channel) {
 
-	unsigned char* term = NULL;
+	char* term = NULL;
 
 	TRACE(("enter send_chansess_pty_req"))
 
@@ -286,7 +286,7 @@ static void send_chansess_pty_req(struct Channel *channel) {
 	if (term == NULL) {
 		term = "vt100"; /* Seems a safe default */
 	}
-	buf_putstring(ses.writepayload, term, strlen(term));
+	buf_putstring(ses.writepayload, (const unsigned char *)term, strlen(term));
 
 	/* Window size */
 	put_winsize();
@@ -305,7 +305,7 @@ static void send_chansess_pty_req(struct Channel *channel) {
 
 static void send_chansess_shell_req(struct Channel *channel) {
 
-	unsigned char* reqtype = NULL;
+	char* reqtype = NULL;
 
 	TRACE(("enter send_chansess_shell_req"))
 
@@ -324,7 +324,7 @@ static void send_chansess_shell_req(struct Channel *channel) {
 	/* XXX TODO */
 	buf_putbyte(ses.writepayload, 0); /* Don't want replies */
 	if (cli_opts.cmd) {
-		buf_putstring(ses.writepayload, cli_opts.cmd, strlen(cli_opts.cmd));
+		buf_putstring(ses.writepayload, (const unsigned char *)cli_opts.cmd, strlen(cli_opts.cmd));
 	}
 
 	encrypt_packet();
@@ -392,7 +392,7 @@ static const struct ChanType cli_chan_netcat = {
 
 void cli_send_netcat_request() {
 
-	const unsigned char* source_host = "127.0.0.1";
+	const char* source_host = "127.0.0.1";
 	const int source_port = 22;
 
 	TRACE(("enter cli_send_netcat_request"))
@@ -403,12 +403,12 @@ void cli_send_netcat_request() {
 		dropbear_exit("Couldn't open initial channel");
 	}
 
-	buf_putstring(ses.writepayload, cli_opts.netcat_host, 
+	buf_putstring(ses.writepayload, (const unsigned char *)cli_opts.netcat_host,
 			strlen(cli_opts.netcat_host));
 	buf_putint(ses.writepayload, cli_opts.netcat_port);
 
 	/* originator ip - localhost is accurate enough */
-	buf_putstring(ses.writepayload, source_host, strlen(source_host));
+	buf_putstring(ses.writepayload, (const unsigned char *)source_host, strlen(source_host));
 	buf_putint(ses.writepayload, source_port);
 
 	encrypt_packet();

--- a/cli-kex.c
+++ b/cli-kex.c
@@ -322,7 +322,7 @@ static void checkhostkey(unsigned char* keyblob, unsigned int keybloblen) {
 		}
 
 		/* Compare hostnames */
-		if (strncmp(cli_opts.remotehost, buf_getptr(line, hostlen),
+		if (strncmp(cli_opts.remotehost, (const char *) buf_getptr(line, hostlen),
 					hostlen) != 0) {
 			continue;
 		}
@@ -334,7 +334,7 @@ static void checkhostkey(unsigned char* keyblob, unsigned int keybloblen) {
 			continue;
 		}
 
-		if (strncmp(buf_getptr(line, algolen), algoname, algolen) != 0) {
+		if (strncmp((const char *) buf_getptr(line, algolen), algoname, algolen) != 0) {
 			TRACE(("algo doesn't match"))
 			continue;
 		}
@@ -346,7 +346,7 @@ static void checkhostkey(unsigned char* keyblob, unsigned int keybloblen) {
 		}
 
 		/* Now we're at the interesting hostkey */
-		ret = cmp_base64_key(keyblob, keybloblen, algoname, algolen,
+		ret = cmp_base64_key(keyblob, keybloblen, (const unsigned char *) algoname, algolen,
 						line, &fingerprint);
 
 		if (ret == DROPBEAR_SUCCESS) {
@@ -382,9 +382,9 @@ static void checkhostkey(unsigned char* keyblob, unsigned int keybloblen) {
 		fseek(hostsfile, 0, SEEK_END); /* In case it wasn't opened append */
 		buf_setpos(line, 0);
 		buf_setlen(line, 0);
-		buf_putbytes(line, cli_opts.remotehost, hostlen);
+		buf_putbytes(line, (const unsigned char *) cli_opts.remotehost, hostlen);
 		buf_putbyte(line, ' ');
-		buf_putbytes(line, algoname, algolen);
+		buf_putbytes(line, (const unsigned char *) algoname, algolen);
 		buf_putbyte(line, ' ');
 		len = line->size - line->pos;
 		/* The only failure with base64 is buffer_overflow, but buf_getwriteptr

--- a/cli-session.c
+++ b/cli-session.c
@@ -192,7 +192,7 @@ static void send_msg_service_request(char* servicename) {
 	CHECKCLEARTOWRITE();
 
 	buf_putbyte(ses.writepayload, SSH_MSG_SERVICE_REQUEST);
-	buf_putstring(ses.writepayload, servicename, strlen(servicename));
+	buf_putstring(ses.writepayload, (const unsigned char *)servicename, strlen(servicename));
 
 	encrypt_packet();
 	TRACE(("leave send_msg_service_request"))
@@ -372,10 +372,10 @@ static void cli_remoteclosed() {
 /* Operates in-place turning dirty (untrusted potentially containing control
  * characters) text into clean text. 
  * Note: this is safe only with ascii - other charsets could have problems. */
-void cleantext(unsigned char* dirtytext) {
+void cleantext(char* dirtytext) {
 
 	unsigned int i, j;
-	unsigned char c;
+	char c;
 
 	j = 0;
 	for (i = 0; dirtytext[i] != '\0'; i++) {

--- a/cli-tcpfwd.c
+++ b/cli-tcpfwd.c
@@ -136,9 +136,9 @@ static void send_msg_global_request_remotetcp(const char *addr, int port) {
 
 	CHECKCLEARTOWRITE();
 	buf_putbyte(ses.writepayload, SSH_MSG_GLOBAL_REQUEST);
-	buf_putstring(ses.writepayload, "tcpip-forward", 13);
+	buf_putstring(ses.writepayload, (const unsigned char *)"tcpip-forward", 13);
 	buf_putbyte(ses.writepayload, 1); /* want_reply */
-	buf_putstring(ses.writepayload, addr, strlen(addr));
+	buf_putstring(ses.writepayload, (const unsigned char *)addr, strlen(addr));
 	buf_putint(ses.writepayload, port);
 
 	encrypt_packet();
@@ -218,7 +218,7 @@ static int newtcpforwarded(struct Channel * channel) {
 	char portstring[NI_MAXSERV];
 	int err = SSH_OPEN_ADMINISTRATIVELY_PROHIBITED;
 
-	origaddr = buf_getstring(ses.payload, NULL);
+	origaddr = (char *)buf_getstring(ses.payload, NULL);
 	origport = buf_getint(ses.payload);
 
 	/* Find which port corresponds. First try and match address as well as port,

--- a/common-algo.c
+++ b/common-algo.c
@@ -322,7 +322,7 @@ void buf_put_algolist(buffer * buf, algo_type localalgos[]) {
 				buf_putbyte(algolist, ',');
 			donefirst = 1;
 			len = strlen(localalgos[i].name);
-			buf_putbytes(algolist, localalgos[i].name, len);
+			buf_putbytes(algolist, (const unsigned char *) localalgos[i].name, len);
 		}
 	}
 	buf_putstring(buf, algolist->data, algolist->len);
@@ -338,19 +338,19 @@ algo_type * buf_match_algo(buffer* buf, algo_type localalgos[],
 		enum kexguess2_used *kexguess2, int *goodguess)
 {
 
-	unsigned char * algolist = NULL;
-	const unsigned char *remotenames[MAX_PROPOSED_ALGO], *localnames[MAX_PROPOSED_ALGO];
+	char * algolist = NULL;
+	const char *remotenames[MAX_PROPOSED_ALGO], *localnames[MAX_PROPOSED_ALGO];
 	unsigned int len;
 	unsigned int remotecount, localcount, clicount, servcount, i, j;
 	algo_type * ret = NULL;
-	const unsigned char **clinames, **servnames;
+	const char **clinames, **servnames;
 
 	if (goodguess) {
 		*goodguess = 0;
 	}
 
 	/* get the comma-separated list from the buffer ie "algo1,algo2,algo3" */
-	algolist = buf_getstring(buf, &len);
+	algolist = (char *) buf_getstring(buf, &len);
 	TRACE(("buf_match_algo: %s", algolist))
 	if (len > MAX_PROPOSED_ALGO*(MAX_NAME_LEN+1)) {
 		goto out;
@@ -488,7 +488,7 @@ algolist_string(algo_type algos[])
 	buf_setpos(b, b->len);
 	buf_putbyte(b, '\0');
 	buf_setpos(b, 4);
-	ret_list = m_strdup(buf_getptr(b, b->len - b->pos));
+	ret_list = m_strdup((const char *) buf_getptr(b, b->len - b->pos));
 	buf_free(b);
 	return ret_list;
 }

--- a/common-channel.c
+++ b/common-channel.c
@@ -38,7 +38,7 @@
 #include "netio.h"
 
 static void send_msg_channel_open_failure(unsigned int remotechan, int reason,
-		const unsigned char *text, const unsigned char *lang);
+		const char *text, const char *lang);
 static void send_msg_channel_open_confirmation(struct Channel* channel,
 		unsigned int recvwindow, 
 		unsigned int recvmaxpacket);
@@ -921,7 +921,7 @@ static void send_msg_channel_window_adjust(struct Channel* channel,
 /* Handle a new channel request, performing any channel-type-specific setup */
 void recv_msg_channel_open() {
 
-	unsigned char *type;
+	char *type;
 	unsigned int typelen;
 	unsigned int remotechan, transwindow, transmaxpacket;
 	struct Channel *channel;
@@ -934,7 +934,7 @@ void recv_msg_channel_open() {
 	TRACE(("enter recv_msg_channel_open"))
 
 	/* get the packet contents */
-	type = buf_getstring(ses.payload, &typelen);
+	type = (char *) buf_getstring(ses.payload, &typelen);
 
 	remotechan = buf_getint(ses.payload);
 	transwindow = buf_getint(ses.payload);
@@ -1039,7 +1039,7 @@ void send_msg_channel_success(struct Channel *channel) {
 /* Send a channel open failure message, with a corresponding reason
  * code (usually resource shortage or unknown chan type) */
 static void send_msg_channel_open_failure(unsigned int remotechan, 
-		int reason, const unsigned char *text, const unsigned char *lang) {
+		int reason, const char *text, const char *lang) {
 
 	TRACE(("enter send_msg_channel_open_failure"))
 	CHECKCLEARTOWRITE();
@@ -1047,8 +1047,8 @@ static void send_msg_channel_open_failure(unsigned int remotechan,
 	buf_putbyte(ses.writepayload, SSH_MSG_CHANNEL_OPEN_FAILURE);
 	buf_putint(ses.writepayload, remotechan);
 	buf_putint(ses.writepayload, reason);
-	buf_putstring(ses.writepayload, text, strlen((char*)text));
-	buf_putstring(ses.writepayload, lang, strlen((char*)lang));
+	buf_putstring(ses.writepayload, (const unsigned char *) text, strlen(text));
+	buf_putstring(ses.writepayload, (const unsigned char *) lang, strlen(lang));
 
 	encrypt_packet();
 	TRACE(("leave send_msg_channel_open_failure"))
@@ -1149,7 +1149,7 @@ int send_msg_channel_open_init(int fd, const struct ChanType *type) {
 	CHECKCLEARTOWRITE();
 
 	buf_putbyte(ses.writepayload, SSH_MSG_CHANNEL_OPEN);
-	buf_putstring(ses.writepayload, type->name, strlen(type->name));
+	buf_putstring(ses.writepayload, (const unsigned char *) type->name, strlen(type->name));
 	buf_putint(ses.writepayload, chan->index);
 	buf_putint(ses.writepayload, opts.recv_window);
 	buf_putint(ses.writepayload, RECV_MAX_CHANNEL_DATA_LEN);
@@ -1244,12 +1244,12 @@ struct Channel* get_any_ready_channel() {
 }
 
 void start_send_channel_request(struct Channel *channel, 
-		unsigned char *type) {
+		char *type) {
 
 	CHECKCLEARTOWRITE();
 	buf_putbyte(ses.writepayload, SSH_MSG_CHANNEL_REQUEST);
 	buf_putint(ses.writepayload, channel->remotechan);
 
-	buf_putstring(ses.writepayload, type, strlen(type));
+	buf_putstring(ses.writepayload, (const unsigned char *) type, strlen(type));
 
 }

--- a/common-kex.c
+++ b/common-kex.c
@@ -128,10 +128,10 @@ void send_msg_kexinit() {
 	buf_put_algolist(ses.writepayload, ses.compress_algos);
 
 	/* languages_client_to_server */
-	buf_putstring(ses.writepayload, "", 0);
+	buf_putstring(ses.writepayload, (const unsigned char *) "", 0);
 
 	/* languages_server_to_client */
-	buf_putstring(ses.writepayload, "", 0);
+	buf_putstring(ses.writepayload, (const unsigned char *) "", 0);
 
 	/* first_kex_packet_follows */
 	buf_putbyte(ses.writepayload, (ses.send_kex_first_guess != NULL));
@@ -511,7 +511,7 @@ void recv_msg_kexinit() {
 
 	/* start the kex hash */
 	local_ident_len = strlen(LOCAL_IDENT);
-	remote_ident_len = strlen((char*)ses.remoteident);
+	remote_ident_len = strlen(ses.remoteident);
 
 	kexhashbuf_len = local_ident_len + remote_ident_len
 		+ ses.transkexinit->len + ses.payload->len
@@ -528,7 +528,7 @@ void recv_msg_kexinit() {
 	    buf_putstring(ses.kexhashbuf,
 			(unsigned char*)LOCAL_IDENT, local_ident_len);
 		/* V_S, the server's version string (CR and NL excluded) */
-	    buf_putstring(ses.kexhashbuf, ses.remoteident, remote_ident_len);
+	    buf_putstring(ses.kexhashbuf, (unsigned char*)ses.remoteident, remote_ident_len);
 
 		/* I_C, the payload of the client's SSH_MSG_KEXINIT */
 	    buf_putstring(ses.kexhashbuf,
@@ -545,7 +545,7 @@ void recv_msg_kexinit() {
 		/* read the peer's choice of algos */
 		read_kex_algos();
 		/* V_C, the client's version string (CR and NL excluded) */
-	    buf_putstring(ses.kexhashbuf, ses.remoteident, remote_ident_len);
+	    buf_putstring(ses.kexhashbuf, (unsigned char*)ses.remoteident, remote_ident_len);
 		/* V_S, the server's version string (CR and NL excluded) */
 	    buf_putstring(ses.kexhashbuf, 
 				(unsigned char*)LOCAL_IDENT, local_ident_len);

--- a/common-session.c
+++ b/common-session.c
@@ -329,7 +329,7 @@ void session_cleanup() {
 
 void send_session_identification() {
 	buffer *writebuf = buf_new(strlen(LOCAL_IDENT "\r\n") + 1);
-	buf_putbytes(writebuf, LOCAL_IDENT "\r\n", strlen(LOCAL_IDENT "\r\n"));
+	buf_putbytes(writebuf, (const unsigned char *) LOCAL_IDENT "\r\n", strlen(LOCAL_IDENT "\r\n"));
 	writebuf_enqueue(writebuf, 0);
 }
 
@@ -469,7 +469,7 @@ static void send_msg_keepalive() {
 		/* Some peers will reply with SSH_MSG_REQUEST_FAILURE, 
 		some will reply with SSH_MSG_UNIMPLEMENTED, some will exit. */
 		buf_putbyte(ses.writepayload, SSH_MSG_GLOBAL_REQUEST); 
-		buf_putstring(ses.writepayload, DROPBEAR_KEEPALIVE_STRING,
+		buf_putstring(ses.writepayload, (const unsigned char *) DROPBEAR_KEEPALIVE_STRING,
 			strlen(DROPBEAR_KEEPALIVE_STRING));
 	}
 	buf_putbyte(ses.writepayload, 1); /* want_reply */

--- a/configure.ac
+++ b/configure.ac
@@ -265,7 +265,7 @@ AC_CACHE_CHECK([for struct sockaddr_storage], ac_cv_have_struct_sockaddr_storage
 #include <sys/types.h>
 #include <sys/socket.h>
 		]],
-		[[ struct sockaddr_storage s; ]])],
+		[[ if (sizeof(struct sockaddr_storage)) return 0 ]])],
 		[ ac_cv_have_struct_sockaddr_storage="yes" ],
 		[ ac_cv_have_struct_sockaddr_storage="no" ]
 	)
@@ -279,7 +279,7 @@ AC_CACHE_CHECK([for struct sockaddr_in6], ac_cv_have_struct_sockaddr_in6, [
 #include <sys/types.h>
 #include <netinet/in.h>
 		]],
-		[[ struct sockaddr_in6 s; s.sin6_family = 0; ]])],
+		[[ if (sizeof(struct sockaddr_in6)) return 0 ]])],
 		[ ac_cv_have_struct_sockaddr_in6="yes" ],
 		[ ac_cv_have_struct_sockaddr_in6="no" ]
 	)
@@ -293,7 +293,7 @@ AC_CACHE_CHECK([for struct in6_addr], ac_cv_have_struct_in6_addr, [
 #include <sys/types.h>
 #include <netinet/in.h>
 		]],
-		[[ struct in6_addr s; s.s6_addr[0] = 0; ]])],
+		[[ if (sizeof(struct in6_addr)) return 0 ]])],
 		[ ac_cv_have_struct_in6_addr="yes" ],
 		[ ac_cv_have_struct_in6_addr="no" ]
 	)
@@ -308,7 +308,7 @@ AC_CACHE_CHECK([for struct addrinfo], ac_cv_have_struct_addrinfo, [
 #include <sys/socket.h>
 #include <netdb.h>
 		]],
-		[[ struct addrinfo s; s.ai_flags = AI_PASSIVE; ]])],
+		[[ if (sizeof(struct addrinfo)) return 0 ]])],
 		[ ac_cv_have_struct_addrinfo="yes" ],
 		[ ac_cv_have_struct_addrinfo="no" ]
 	)

--- a/dbrandom.c
+++ b/dbrandom.c
@@ -141,7 +141,7 @@ out:
 	return ret;
 }
 
-void addrandom(char * buf, unsigned int len)
+void addrandom(unsigned char * buf, unsigned int len)
 {
 	hash_state hs;
 

--- a/dbrandom.h
+++ b/dbrandom.h
@@ -29,7 +29,7 @@
 
 void seedrandom();
 void genrandom(unsigned char* buf, unsigned int len);
-void addrandom(char * buf, unsigned int len);
+void addrandom(unsigned char * buf, unsigned int len);
 void gen_random_mpint(mp_int *max, mp_int *rand);
 
 #endif /* DROPBEAR_RANDOM_H_ */

--- a/dss.c
+++ b/dss.c
@@ -136,7 +136,7 @@ void dss_key_free(dropbear_dss_key *key) {
 void buf_put_dss_pub_key(buffer* buf, dropbear_dss_key *key) {
 
 	dropbear_assert(key != NULL);
-	buf_putstring(buf, SSH_SIGNKEY_DSS, SSH_SIGNKEY_DSS_LEN);
+	buf_putstring(buf, (const unsigned char*) SSH_SIGNKEY_DSS, SSH_SIGNKEY_DSS_LEN);
 	buf_putmpint(buf, key->p);
 	buf_putmpint(buf, key->q);
 	buf_putmpint(buf, key->g);
@@ -165,7 +165,7 @@ int buf_dss_verify(buffer* buf, dropbear_dss_key *key, buffer *data_buf) {
 	DEF_MP_INT(val3);
 	DEF_MP_INT(val4);
 	char * string = NULL;
-	int stringlen;
+	unsigned int stringlen;
 
 	TRACE(("enter buf_dss_verify"))
 	dropbear_assert(key != NULL);
@@ -173,7 +173,7 @@ int buf_dss_verify(buffer* buf, dropbear_dss_key *key, buffer *data_buf) {
 	m_mp_init_multi(&val1, &val2, &val3, &val4, NULL);
 
 	/* get blob, check length */
-	string = buf_getstring(buf, &stringlen);
+	string = (char*) buf_getstring(buf, &stringlen);
 	if (stringlen != 2*SHA1_HASH_SIZE) {
 		goto out;
 	}
@@ -186,7 +186,7 @@ int buf_dss_verify(buffer* buf, dropbear_dss_key *key, buffer *data_buf) {
 	/* create the signature - s' and r' are the received signatures in buf */
 	/* w = (s')-1 mod q */
 	/* let val1 = s' */
-	bytes_to_mp(&val1, &string[SHA1_HASH_SIZE], SHA1_HASH_SIZE);
+	bytes_to_mp(&val1, (const unsigned char*) &string[SHA1_HASH_SIZE], SHA1_HASH_SIZE);
 
 	if (mp_cmp(&val1, key->q) != MP_LT) {
 		TRACE(("verify failed, s' >= q"))
@@ -208,7 +208,7 @@ int buf_dss_verify(buffer* buf, dropbear_dss_key *key, buffer *data_buf) {
 
 	/* u2 = ((r')w) mod q */
 	/* let val1 = r' */
-	bytes_to_mp(&val1, &string[0], SHA1_HASH_SIZE);
+	bytes_to_mp(&val1, (const unsigned char*) &string[0], SHA1_HASH_SIZE);
 	if (mp_cmp(&val1, key->q) != MP_LT) {
 		TRACE(("verify failed, r' >= q"))
 		goto out;
@@ -310,7 +310,7 @@ void buf_put_dss_sign(buffer* buf, dropbear_dss_key *key, buffer *data_buf) {
 		dropbear_exit("DSS error");
 	}
 
-	buf_putstring(buf, SSH_SIGNKEY_DSS, SSH_SIGNKEY_DSS_LEN);
+	buf_putstring(buf, (const unsigned char*) SSH_SIGNKEY_DSS, SSH_SIGNKEY_DSS_LEN);
 	buf_putint(buf, 2*SHA1_HASH_SIZE);
 
 	writelen = mp_unsigned_bin_size(&dss_r);

--- a/ecc.h
+++ b/ecc.h
@@ -12,7 +12,7 @@ struct dropbear_ecc_curve {
 	int ltc_size; /* to match the byte sizes in ltc_ecc_sets[] */
 	const ltc_ecc_set_type *dp; /* curve domain parameters */
 	const struct ltc_hash_descriptor *hash_desc;
-	const unsigned char *name;
+	const char *name;
 };
 
 extern struct dropbear_ecc_curve ecc_curve_nistp256;

--- a/ecdsa.c
+++ b/ecdsa.c
@@ -140,12 +140,12 @@ ecc_key *buf_get_ecdsa_priv_key(buffer *buf) {
 
 void buf_put_ecdsa_pub_key(buffer *buf, ecc_key *key) {
 	struct dropbear_ecc_curve *curve = NULL;
-	unsigned char key_ident[30];
+	char key_ident[30];
 
 	curve = curve_for_dp(key->dp);
-	snprintf((char*)key_ident, sizeof(key_ident), "ecdsa-sha2-%s", curve->name);
-	buf_putstring(buf, key_ident, strlen(key_ident));
-	buf_putstring(buf, curve->name, strlen(curve->name));
+	snprintf(key_ident, sizeof(key_ident), "ecdsa-sha2-%s", curve->name);
+	buf_putstring(buf, (const unsigned char *) key_ident, strlen(key_ident));
+	buf_putstring(buf, (const unsigned char *) curve->name, strlen(curve->name));
 	buf_put_ecc_raw_pubkey_string(buf, key);
 }
 
@@ -161,7 +161,7 @@ void buf_put_ecdsa_sign(buffer *buf, ecc_key *key, buffer *data_buf) {
 	hash_state hs;
 	unsigned char hash[64];
 	void *e = NULL, *p = NULL, *s = NULL, *r;
-	unsigned char key_ident[30];
+	char key_ident[30];
 	buffer *sigbuf = NULL;
 
 	TRACE(("buf_put_ecdsa_sign"))
@@ -222,8 +222,8 @@ void buf_put_ecdsa_sign(buffer *buf, ecc_key *key, buffer *data_buf) {
 		}
 	}
 
-	snprintf((char*)key_ident, sizeof(key_ident), "ecdsa-sha2-%s", curve->name);
-	buf_putstring(buf, key_ident, strlen(key_ident));
+	snprintf(key_ident, sizeof(key_ident), "ecdsa-sha2-%s", curve->name);
+	buf_putstring(buf, (const unsigned char *) key_ident, strlen(key_ident));
 	/* enough for nistp521 */
 	sigbuf = buf_new(200);
 	buf_putmpint(sigbuf, (mp_int*)r);

--- a/gendss.c
+++ b/gendss.c
@@ -67,7 +67,7 @@ dropbear_dss_key * gen_dss_priv_key(unsigned int size) {
 
 static void getq(dropbear_dss_key *key) {
 
-	char buf[QSIZE];
+	unsigned char buf[QSIZE];
 
 	/* 160 bit prime */
 	genrandom(buf, QSIZE);

--- a/keyimport.c
+++ b/keyimport.c
@@ -1043,7 +1043,7 @@ static int openssh_write(const char *filename, sign_key *key,
 		int curve_oid_len = 0;
 		const void* curve_oid = NULL;
 		unsigned long pubkey_size = 2*curve_size+1;
-		unsigned int k_size;
+		int k_size;
 		int err = 0;
 
 		/* version. less than 10 bytes */

--- a/keyimport.c
+++ b/keyimport.c
@@ -193,7 +193,7 @@ out:
 static void base64_encode_fp(FILE * fp, unsigned char *data,
 		int datalen, int cpl)
 {
-    char out[100];
+	unsigned char out[100];
     int n;
 	unsigned long outlen;
 	int rawcpl;
@@ -445,7 +445,7 @@ static struct openssh_key *load_openssh_key(const char *filename)
 						ret->keyblob_size);
 			}
 			outlen = ret->keyblob_size - ret->keyblob_len;
-			if (base64_decode(buffer, len, 
+			if (base64_decode((const unsigned char *)buffer, len,
 						ret->keyblob + ret->keyblob_len, &outlen) != CRYPT_OK){
 				errmsg = "Error decoding base64";
 				goto error;
@@ -507,7 +507,7 @@ static sign_key *openssh_read(const char *filename, char * UNUSED(passphrase))
 	int i, num_integers = 0;
 	sign_key *retval = NULL;
 	char *errmsg;
-	char *modptr = NULL;
+	unsigned char *modptr = NULL;
 	int modlen = -9999;
 	enum signkey_type type;
 
@@ -602,13 +602,13 @@ static sign_key *openssh_read(const char *filename, char * UNUSED(passphrase))
 
 #ifdef DROPBEAR_DSS
 	if (key->type == OSSH_DSA) {
-		buf_putstring(blobbuf, "ssh-dss", 7);
+		buf_putstring(blobbuf, (const unsigned char *)"ssh-dss", 7);
 		retkey->type = DROPBEAR_SIGNKEY_DSS;
 	} 
 #endif
 #ifdef DROPBEAR_RSA
 	if (key->type == OSSH_RSA) {
-		buf_putstring(blobbuf, "ssh-rsa", 7);
+		buf_putstring(blobbuf, (const unsigned char *)"ssh-rsa", 7);
 		retkey->type = DROPBEAR_SIGNKEY_RSA;
 	}
 #endif
@@ -646,7 +646,7 @@ static sign_key *openssh_read(const char *filename, char * UNUSED(passphrase))
 			 */
 			if (i == 1) {
 				/* Save the details for after we deal with number 2. */
-				modptr = (char *)p;
+				modptr = p;
 				modlen = len;
 			} else if (i >= 2 && i <= 5) {
 				buf_putstring(blobbuf, p, len);

--- a/libtomcrypt/src/ciphers/aes/aes.c
+++ b/libtomcrypt/src/ciphers/aes/aes.c
@@ -122,9 +122,10 @@ static ulong32 setup_mix2(ulong32 temp)
  */
 int SETUP(const unsigned char *key, int keylen, int num_rounds, symmetric_key *skey)
 {
-    int i, j;
+    int i;
     ulong32 temp, *rk;
 #ifndef ENCRYPT_ONLY
+    int j;
     ulong32 *rrk;
 #endif    
     LTC_ARGCHK(key  != NULL);
@@ -148,7 +149,9 @@ int SETUP(const unsigned char *key, int keylen, int num_rounds, symmetric_key *s
     LOAD32H(rk[2], key +  8);
     LOAD32H(rk[3], key + 12);
     if (keylen == 16) {
+        #ifndef ENCRYPT_ONLY
         j = 44;
+        #endif
         for (;;) {
             temp  = rk[3];
             rk[4] = rk[0] ^ setup_mix(temp) ^ rcon[i];
@@ -161,7 +164,9 @@ int SETUP(const unsigned char *key, int keylen, int num_rounds, symmetric_key *s
             rk += 4;
         }
     } else if (keylen == 24) {
+        #ifndef ENCRYPT_ONLY
         j = 52;   
+        #endif
         LOAD32H(rk[4], key + 16);
         LOAD32H(rk[5], key + 20);
         for (;;) {
@@ -182,7 +187,9 @@ int SETUP(const unsigned char *key, int keylen, int num_rounds, symmetric_key *s
             rk += 6;
         }
     } else if (keylen == 32) {
+        #ifndef ENCRYPT_ONLY
         j = 60;
+        #endif
         LOAD32H(rk[4], key + 16);
         LOAD32H(rk[5], key + 20);
         LOAD32H(rk[6], key + 24);

--- a/libtomcrypt/src/ciphers/aes/aes.c
+++ b/libtomcrypt/src/ciphers/aes/aes.c
@@ -728,6 +728,7 @@ int ECB_TEST(void)
 */
 void ECB_DONE(symmetric_key *skey)
 {
+   (void)skey;
 }
 
 

--- a/libtomcrypt/src/ciphers/des.c
+++ b/libtomcrypt/src/ciphers/des.c
@@ -1871,6 +1871,7 @@ void des_done(symmetric_key *skey)
 */
 void des3_done(symmetric_key *skey)
 {
+   (void)skey;
 }
 
 

--- a/libtomcrypt/src/ciphers/twofish/twofish.c
+++ b/libtomcrypt/src/ciphers/twofish/twofish.c
@@ -684,6 +684,7 @@ int twofish_test(void)
 */
 void twofish_done(symmetric_key *skey)
 {
+   (void)skey;
 }
 
 /**

--- a/libtomcrypt/src/hashes/helper/hash_file.c
+++ b/libtomcrypt/src/hashes/helper/hash_file.c
@@ -25,6 +25,7 @@
 int hash_file(int hash, const char *fname, unsigned char *out, unsigned long *outlen)
 {
 #ifdef LTC_NO_FILE
+    (void)hash; (void)fname; (void)out; (void)outlen;
     return CRYPT_NOP;
 #else
     FILE *in;

--- a/libtomcrypt/src/hashes/helper/hash_filehandle.c
+++ b/libtomcrypt/src/hashes/helper/hash_filehandle.c
@@ -26,6 +26,7 @@
 int hash_filehandle(int hash, FILE *in, unsigned char *out, unsigned long *outlen)
 {
 #ifdef LTC_NO_FILE
+    (void)hash; (void)in; (void)out; (void)outlen;
     return CRYPT_NOP;
 #else
     hash_state md;

--- a/libtomcrypt/src/mac/hmac/hmac_file.c
+++ b/libtomcrypt/src/mac/hmac/hmac_file.c
@@ -32,6 +32,7 @@ int hmac_file(int hash, const char *fname,
                     unsigned char *out, unsigned long *outlen)
 {
 #ifdef LTC_NO_FILE
+    (void)hash; (void)fname; (void)key; (void)keylen; (void)out; (void)outlen;
     return CRYPT_NOP;
 #else
    hmac_state hmac;

--- a/libtomcrypt/src/misc/crypt/crypt_argchk.c
+++ b/libtomcrypt/src/misc/crypt/crypt_argchk.c
@@ -21,7 +21,7 @@ void crypt_argchk(char *v, char *s, int d)
 {
  fprintf(stderr, "LTC_ARGCHK '%s' failure on line %d of file %s\n",
          v, d, s);
- (void)raise(SIGABRT);
+ abort();
 }
 #endif
 

--- a/libtomcrypt/src/pk/ecc/ltc_ecc_mulmod_timing.c
+++ b/libtomcrypt/src/pk/ecc/ltc_ecc_mulmod_timing.c
@@ -40,7 +40,7 @@ int ltc_ecc_mulmod(void *k, ecc_point *G, ecc_point *R, void *modulus, int map)
    int        i, j, err;
    void       *mu, *mp;
    unsigned long buf;
-   int        first, bitbuf, bitcpy, bitcnt, mode, digidx;
+   int        bitcnt, mode, digidx;
 
    LTC_ARGCHK(k       != NULL);
    LTC_ARGCHK(G       != NULL);
@@ -98,8 +98,6 @@ int ltc_ecc_mulmod(void *k, ecc_point *G, ecc_point *R, void *modulus, int map)
    bitcnt = 1;
    buf    = 0;
    digidx = mp_get_digit_count(k) - 1;
-   bitcpy = bitbuf = 0;
-   first  = 1;
 
    /* perform ops */
    for (;;) {

--- a/netio.c
+++ b/netio.c
@@ -100,7 +100,7 @@ static void connect_try_next(struct dropbear_progress_connection *c) {
 
 		if (c->writequeue) {
 			/* 6 is arbitrary, enough to hold initial packets */
-			int iovlen = 6; /* Linux msg_iovlen is a size_t */
+			unsigned int iovlen = 6; /* Linux msg_iovlen is a size_t */
 			struct iovec iov[6];
 			packet_queue_to_iovec(c->writequeue, iov, &iovlen);
 			message.msg_iov = iov;

--- a/rsa.c
+++ b/rsa.c
@@ -174,7 +174,7 @@ void buf_put_rsa_pub_key(buffer* buf, dropbear_rsa_key *key) {
 	TRACE(("enter buf_put_rsa_pub_key"))
 	dropbear_assert(key != NULL);
 
-	buf_putstring(buf, SSH_SIGNKEY_RSA, SSH_SIGNKEY_RSA_LEN);
+	buf_putstring(buf, (const unsigned char *) SSH_SIGNKEY_RSA, SSH_SIGNKEY_RSA_LEN);
 	buf_putmpint(buf, key->e);
 	buf_putmpint(buf, key->n);
 
@@ -327,7 +327,7 @@ void buf_put_rsa_sign(buffer* buf, dropbear_rsa_key *key, buffer *data_buf) {
 	mp_clear_multi(&rsa_tmp1, &rsa_tmp2, &rsa_tmp3, NULL);
 	
 	/* create the signature to return */
-	buf_putstring(buf, SSH_SIGNKEY_RSA, SSH_SIGNKEY_RSA_LEN);
+	buf_putstring(buf, (const unsigned char *) SSH_SIGNKEY_RSA, SSH_SIGNKEY_RSA_LEN);
 
 	nsize = mp_unsigned_bin_size(key->n);
 

--- a/session.h
+++ b/session.h
@@ -63,7 +63,7 @@ void svr_dropbear_log(int priority, const char* format, va_list param);
 /* Client */
 void cli_session(int sock_in, int sock_out, struct dropbear_progress_connection *progress) ATTRIB_NORETURN;
 void cli_connected(int result, int sock, void* userdata, const char *errstring);
-void cleantext(unsigned char* dirtytext);
+void cleantext(char* dirtytext);
 
 /* crypto parameters that are stored individually for transmit and receive */
 struct key_context_directional {
@@ -115,7 +115,7 @@ struct sshsession {
 	/* remotehost will be initially NULL as we delay
 	 * reading the remote version string. it will be set
 	 * by the time any recv_() packet methods are called */
-	unsigned char *remoteident; 
+	char *remoteident;
 
 	int maxfd; /* the maximum file descriptor to check with select() */
 

--- a/signkey.c
+++ b/signkey.c
@@ -138,14 +138,14 @@ signkey_key_ptr(sign_key *key, enum signkey_type type) {
  * on return is set to the type read (useful when type = _ANY) */
 int buf_get_pub_key(buffer *buf, sign_key *key, enum signkey_type *type) {
 
-	unsigned char* ident;
+	char *ident;
 	unsigned int len;
 	enum signkey_type keytype;
 	int ret = DROPBEAR_FAILURE;
 
 	TRACE2(("enter buf_get_pub_key"))
 
-	ident = buf_getstring(buf, &len);
+	ident = (char *) buf_getstring(buf, &len);
 	keytype = signkey_type_from_name(ident, len);
 	m_free(ident);
 
@@ -209,14 +209,14 @@ int buf_get_pub_key(buffer *buf, sign_key *key, enum signkey_type *type) {
  * on return is set to the type read (useful when type = _ANY) */
 int buf_get_priv_key(buffer *buf, sign_key *key, enum signkey_type *type) {
 
-	unsigned char* ident;
+	char *ident;
 	unsigned int len;
 	enum signkey_type keytype;
 	int ret = DROPBEAR_FAILURE;
 
 	TRACE2(("enter buf_get_priv_key"))
 
-	ident = buf_getstring(buf, &len);
+	ident = (char *)buf_getstring(buf, &len);
 	keytype = signkey_type_from_name(ident, len);
 	m_free(ident);
 
@@ -515,14 +515,14 @@ void buf_put_sign(buffer* buf, sign_key *key, enum signkey_type type,
  * signature blob */
 int buf_verify(buffer * buf, sign_key *key, buffer *data_buf) {
 	
-	unsigned char * type_name = NULL;
+	char *type_name = NULL;
 	unsigned int type_name_len = 0;
 	enum signkey_type type;
 
 	TRACE(("enter buf_verify"))
 
 	buf_getint(buf); /* blob length */
-	type_name = buf_getstring(buf, &type_name_len);
+	type_name = (char *) buf_getstring(buf, &type_name_len);
 	type = signkey_type_from_name(type_name, type_name_len);
 	m_free(type_name);
 

--- a/svr-auth.c
+++ b/svr-auth.c
@@ -36,7 +36,7 @@
 #include "dbrandom.h"
 
 static void authclear();
-static int checkusername(unsigned char *username, unsigned int userlen);
+static int checkusername(char *username, unsigned int userlen);
 
 /* initialise the first time for a session, resetting all parameters */
 void svr_authinitialise() {
@@ -89,7 +89,7 @@ void send_msg_userauth_banner(buffer *banner) {
 
 	buf_putbyte(ses.writepayload, SSH_MSG_USERAUTH_BANNER);
 	buf_putbufstring(ses.writepayload, banner);
-	buf_putstring(ses.writepayload, "en", 2);
+	buf_putstring(ses.writepayload, (const unsigned char *)"en", 2);
 
 	encrypt_packet();
 
@@ -100,7 +100,7 @@ void send_msg_userauth_banner(buffer *banner) {
  * checking, and handle success or failure */
 void recv_msg_userauth_request() {
 
-	unsigned char *username = NULL, *servicename = NULL, *methodname = NULL;
+	char *username = NULL, *servicename = NULL, *methodname = NULL;
 	unsigned int userlen, servicelen, methodlen;
 	int valid_user = 0;
 
@@ -119,9 +119,9 @@ void recv_msg_userauth_request() {
 		svr_opts.banner = NULL;
 	}
 
-	username = buf_getstring(ses.payload, &userlen);
-	servicename = buf_getstring(ses.payload, &servicelen);
-	methodname = buf_getstring(ses.payload, &methodlen);
+	username = (char *)buf_getstring(ses.payload, &userlen);
+	servicename = (char *)buf_getstring(ses.payload, &servicelen);
+	methodname = (char *)buf_getstring(ses.payload, &methodlen);
 
 	/* only handle 'ssh-connection' currently */
 	if (servicelen != SSH_SERVICE_CONNECTION_LEN
@@ -227,7 +227,7 @@ out:
 
 /* Check that the username exists and isn't disallowed (root), and has a valid shell.
  * returns DROPBEAR_SUCCESS on valid username, DROPBEAR_FAILURE on failure */
-static int checkusername(unsigned char *username, unsigned int userlen) {
+static int checkusername(char *username, unsigned int userlen) {
 
 	char* listshell = NULL;
 	char* usershell = NULL;
@@ -333,14 +333,14 @@ void send_msg_userauth_failure(int partial, int incrfail) {
 	typebuf = buf_new(30); /* long enough for PUBKEY and PASSWORD */
 
 	if (ses.authstate.authtypes & AUTH_TYPE_PUBKEY) {
-		buf_putbytes(typebuf, AUTH_METHOD_PUBKEY, AUTH_METHOD_PUBKEY_LEN);
+		buf_putbytes(typebuf, (const unsigned char *)AUTH_METHOD_PUBKEY, AUTH_METHOD_PUBKEY_LEN);
 		if (ses.authstate.authtypes & AUTH_TYPE_PASSWORD) {
 			buf_putbyte(typebuf, ',');
 		}
 	}
 	
 	if (ses.authstate.authtypes & AUTH_TYPE_PASSWORD) {
-		buf_putbytes(typebuf, AUTH_METHOD_PASSWORD, AUTH_METHOD_PASSWORD_LEN);
+		buf_putbytes(typebuf, (const unsigned char *)AUTH_METHOD_PASSWORD, AUTH_METHOD_PASSWORD_LEN);
 	}
 
 	buf_putbufstring(ses.writepayload, typebuf);

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -70,10 +70,10 @@
 #define MIN_AUTHKEYS_LINE 10 /* "ssh-rsa AB" - short but doesn't matter */
 #define MAX_AUTHKEYS_LINE 4200 /* max length of a line in authkeys */
 
-static int checkpubkey(unsigned char* algo, unsigned int algolen,
+static int checkpubkey(char* algo, unsigned int algolen,
 		unsigned char* keyblob, unsigned int keybloblen);
 static int checkpubkeyperms();
-static void send_msg_userauth_pk_ok(unsigned char* algo, unsigned int algolen,
+static void send_msg_userauth_pk_ok(char* algo, unsigned int algolen,
 		unsigned char* keyblob, unsigned int keybloblen);
 static int checkfileperm(char * filename);
 
@@ -82,7 +82,7 @@ static int checkfileperm(char * filename);
 void svr_auth_pubkey() {
 
 	unsigned char testkey; /* whether we're just checking if a key is usable */
-	unsigned char* algo = NULL; /* pubkey algo */
+	char* algo = NULL; /* pubkey algo */
 	unsigned int algolen;
 	unsigned char* keyblob = NULL;
 	unsigned int keybloblen;
@@ -98,7 +98,7 @@ void svr_auth_pubkey() {
 	 * actual attempt*/
 	testkey = (buf_getbool(ses.payload) == 0);
 
-	algo = buf_getstring(ses.payload, &algolen);
+	algo = (char *) buf_getstring(ses.payload, &algolen);
 	keybloblen = buf_getint(ses.payload);
 	keyblob = buf_getptr(ses.payload, keybloblen);
 
@@ -173,14 +173,14 @@ out:
 /* Reply that the key is valid for auth, this is sent when the user sends
  * a straight copy of their pubkey to test, to avoid having to perform
  * expensive signing operations with a worthless key */
-static void send_msg_userauth_pk_ok(unsigned char* algo, unsigned int algolen,
+static void send_msg_userauth_pk_ok(char* algo, unsigned int algolen,
 		unsigned char* keyblob, unsigned int keybloblen) {
 
 	TRACE(("enter send_msg_userauth_pk_ok"))
 	CHECKCLEARTOWRITE();
 
 	buf_putbyte(ses.writepayload, SSH_MSG_USERAUTH_PK_OK);
-	buf_putstring(ses.writepayload, algo, algolen);
+	buf_putstring(ses.writepayload, (const unsigned char *) algo, algolen);
 	buf_putstring(ses.writepayload, keyblob, keybloblen);
 
 	encrypt_packet();
@@ -191,7 +191,7 @@ static void send_msg_userauth_pk_ok(unsigned char* algo, unsigned int algolen,
 /* Checks whether a specified publickey (and associated algorithm) is an
  * acceptable key for authentication */
 /* Returns DROPBEAR_SUCCESS if key is ok for auth, DROPBEAR_FAILURE otherwise */
-static int checkpubkey(unsigned char* algo, unsigned int algolen,
+static int checkpubkey(char* algo, unsigned int algolen,
 		unsigned char* keyblob, unsigned int keybloblen) {
 
 	FILE * authfile = NULL;
@@ -260,9 +260,9 @@ static int checkpubkey(unsigned char* algo, unsigned int algolen,
 		/* check the key type - will fail if there are options */
 		TRACE(("a line!"))
 
-		if (strncmp(buf_getptr(line, algolen), algo, algolen) != 0) {
+		if (strncmp((const char *) buf_getptr(line, algolen), algo, algolen) != 0) {
 			int is_comment = 0;
-			char *options_start = NULL;
+			unsigned char *options_start = NULL;
 			int options_len = 0;
 			int escape, quoted;
 			
@@ -308,7 +308,7 @@ static int checkpubkey(unsigned char* algo, unsigned int algolen,
 			if (line->pos + algolen+3 > line->len) {
 				continue;
 			}
-			if (strncmp(buf_getptr(line, algolen), algo, algolen) != 0) { 
+			if (strncmp((const char *) buf_getptr(line, algolen), algo, algolen) != 0) {
 				continue;
 			}
 		}
@@ -330,7 +330,7 @@ static int checkpubkey(unsigned char* algo, unsigned int algolen,
 
 		TRACE(("checkpubkey: line pos = %d len = %d", line->pos, line->len))
 
-		ret = cmp_base64_key(keyblob, keybloblen, algo, algolen, line, NULL);
+		ret = cmp_base64_key(keyblob, keybloblen, (const unsigned char *) algo, algolen, line, NULL);
 
 		if (ret == DROPBEAR_SUCCESS && options_buf) {
 			ret = svr_add_pubkey_options(options_buf, line_num, filename);

--- a/svr-authpubkeyoptions.c
+++ b/svr-authpubkeyoptions.c
@@ -120,7 +120,7 @@ static int match_option(buffer *options_buf, const char *opt_name) {
 	if (options_buf->len - options_buf->pos < len) {
 		return DROPBEAR_FAILURE;
 	}
-	if (strncasecmp(buf_getptr(options_buf, len), opt_name, len) == 0) {
+	if (strncasecmp((const char *) buf_getptr(options_buf, len), opt_name, len) == 0) {
 		buf_incrpos(options_buf, len);
 		return DROPBEAR_SUCCESS;
 	}

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -183,7 +183,7 @@ static void send_msg_chansess_exitstatus(struct Channel * channel,
 
 	buf_putbyte(ses.writepayload, SSH_MSG_CHANNEL_REQUEST);
 	buf_putint(ses.writepayload, channel->remotechan);
-	buf_putstring(ses.writepayload, "exit-status", 11);
+	buf_putstring(ses.writepayload, (const unsigned char *) "exit-status", 11);
 	buf_putbyte(ses.writepayload, 0); /* boolean FALSE */
 	buf_putint(ses.writepayload, chansess->exit.exitstatus);
 
@@ -219,12 +219,12 @@ static void send_msg_chansess_exitsignal(struct Channel * channel,
 
 	buf_putbyte(ses.writepayload, SSH_MSG_CHANNEL_REQUEST);
 	buf_putint(ses.writepayload, channel->remotechan);
-	buf_putstring(ses.writepayload, "exit-signal", 11);
+	buf_putstring(ses.writepayload, (const unsigned char *) "exit-signal", 11);
 	buf_putbyte(ses.writepayload, 0); /* boolean FALSE */
-	buf_putstring(ses.writepayload, signame, strlen(signame));
+	buf_putstring(ses.writepayload, (const unsigned char *) signame, strlen(signame));
 	buf_putbyte(ses.writepayload, chansess->exit.exitcore);
-	buf_putstring(ses.writepayload, "", 0); /* error msg */
-	buf_putstring(ses.writepayload, "", 0); /* lang */
+	buf_putstring(ses.writepayload, (const unsigned char *) "", 0); /* error msg */
+	buf_putstring(ses.writepayload, (const unsigned char *) "", 0); /* lang */
 
 	encrypt_packet();
 }
@@ -343,7 +343,7 @@ static void closechansess(struct Channel *channel) {
  * or x11/authagent forwarding. These are passed to appropriate handlers */
 static void chansessionrequest(struct Channel *channel) {
 
-	unsigned char * type = NULL;
+	char * type = NULL;
 	unsigned int typelen;
 	unsigned char wantreply;
 	int ret = 1;
@@ -351,7 +351,7 @@ static void chansessionrequest(struct Channel *channel) {
 
 	TRACE(("enter chansessionrequest"))
 
-	type = buf_getstring(ses.payload, &typelen);
+	type = (char *) buf_getstring(ses.payload, &typelen);
 	wantreply = buf_getbool(ses.payload);
 
 	if (typelen > MAX_NAME_LEN) {
@@ -406,7 +406,7 @@ out:
 static int sessionsignal(struct ChanSess *chansess) {
 
 	int sig = 0;
-	unsigned char* signame = NULL;
+	char* signame = NULL;
 	int i;
 
 	if (chansess->pid == 0) {
@@ -414,7 +414,7 @@ static int sessionsignal(struct ChanSess *chansess) {
 		return DROPBEAR_FAILURE;
 	}
 
-	signame = buf_getstring(ses.payload, NULL);
+	signame = (char *) buf_getstring(ses.payload, NULL);
 
 	i = 0;
 	while (signames[i].name != 0) {
@@ -557,7 +557,7 @@ static void get_termmodes(struct ChanSess *chansess) {
 static int sessionpty(struct ChanSess * chansess) {
 
 	unsigned int termlen;
-	unsigned char namebuf[65];
+	char namebuf[65];
 	struct passwd * pw = NULL;
 
 	TRACE(("enter sessionpty"))
@@ -567,7 +567,7 @@ static int sessionpty(struct ChanSess * chansess) {
 		return DROPBEAR_FAILURE;
 	}
 
-	chansess->term = buf_getstring(ses.payload, &termlen);
+	chansess->term = (char *) buf_getstring(ses.payload, &termlen);
 	if (termlen > MAX_TERM_LEN) {
 		/* TODO send disconnect ? */
 		TRACE(("leave sessionpty: term len too long"))
@@ -583,7 +583,7 @@ static int sessionpty(struct ChanSess * chansess) {
 		return DROPBEAR_FAILURE;
 	}
 	
-	chansess->tty = (char*)m_strdup(namebuf);
+	chansess->tty = m_strdup(namebuf);
 	if (!chansess->tty) {
 		dropbear_exit("Out of memory"); /* TODO disconnect */
 	}
@@ -649,7 +649,7 @@ static int sessioncommand(struct Channel *channel, struct ChanSess *chansess,
 	if (iscmd) {
 		/* "exec" */
 		if (chansess->cmd == NULL) {
-			chansess->cmd = buf_getstring(ses.payload, &cmdlen);
+			chansess->cmd = (char *) buf_getstring(ses.payload, &cmdlen);
 
 			if (cmdlen > MAX_CMD_LEN) {
 				m_free(chansess->cmd);

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -603,6 +603,7 @@ static int sessionpty(struct ChanSess * chansess) {
 	return DROPBEAR_SUCCESS;
 }
 
+#ifndef USE_VFORK
 static void make_connection_string(struct ChanSess *chansess) {
 	char *local_ip, *local_port, *remote_ip, *remote_port;
 	size_t len;
@@ -624,6 +625,7 @@ static void make_connection_string(struct ChanSess *chansess) {
 	m_free(remote_ip);
 	m_free(remote_port);
 }
+#endif
 
 /* Handle a command request from the client. This is used for both shell
  * and command-execution requests, and passes the command to

--- a/svr-service.c
+++ b/svr-service.c
@@ -30,18 +30,18 @@
 #include "ssh.h"
 #include "auth.h"
 
-static void send_msg_service_accept(unsigned char *name, int len);
+static void send_msg_service_accept(char *name, int len);
 
 /* processes a SSH_MSG_SERVICE_REQUEST, returning 0 if finished,
  * 1 if not */
 void recv_msg_service_request() {
 
-	unsigned char * name;
+	char * name;
 	unsigned int len;
 
 	TRACE(("enter recv_msg_service_request"))
 
-	name = buf_getstring(ses.payload, &len);
+	name = (char *) buf_getstring(ses.payload, &len);
 
 	/* ssh-userauth */
 	if (len == SSH_SERVICE_USERAUTH_LEN && 
@@ -73,14 +73,14 @@ void recv_msg_service_request() {
 
 }
 
-static void send_msg_service_accept(unsigned char *name, int len) {
+static void send_msg_service_accept(char *name, int len) {
 
 	TRACE(("accepting service %s", name))
 
 	CHECKCLEARTOWRITE();
 
 	buf_putbyte(ses.writepayload, SSH_MSG_SERVICE_ACCEPT);
-	buf_putstring(ses.writepayload, name, len);
+	buf_putstring(ses.writepayload, (const unsigned char *) name, len);
 
 	encrypt_packet();
 

--- a/svr-tcpfwd.c
+++ b/svr-tcpfwd.c
@@ -65,7 +65,7 @@ static const struct ChanType svr_chan_tcpremote = {
  * similar to the request-switching in chansession.c */
 void recv_msg_global_request_remotetcp() {
 
-	unsigned char* reqname = NULL;
+	char* reqname = NULL;
 	unsigned int namelen;
 	unsigned int wantreply = 0;
 	int ret = DROPBEAR_FAILURE;
@@ -77,7 +77,7 @@ void recv_msg_global_request_remotetcp() {
 		goto out;
 	}
 
-	reqname = buf_getstring(ses.payload, &namelen);
+	reqname = (char *)buf_getstring(ses.payload, &namelen);
 	wantreply = buf_getbool(ses.payload);
 
 	if (namelen > MAX_NAME_LEN) {
@@ -120,7 +120,7 @@ static int matchtcp(void* typedata1, void* typedata2) {
 static int svr_cancelremotetcp() {
 
 	int ret = DROPBEAR_FAILURE;
-	unsigned char * bindaddr = NULL;
+	char * bindaddr = NULL;
 	unsigned int addrlen;
 	unsigned int port;
 	struct Listener * listener = NULL;
@@ -128,7 +128,7 @@ static int svr_cancelremotetcp() {
 
 	TRACE(("enter cancelremotetcp"))
 
-	bindaddr = buf_getstring(ses.payload, &addrlen);
+	bindaddr = (char *)buf_getstring(ses.payload, &addrlen);
 	if (addrlen > MAX_IP_LEN) {
 		TRACE(("addr len too long: %d", addrlen))
 		goto out;
@@ -155,14 +155,14 @@ out:
 static int svr_remotetcpreq() {
 
 	int ret = DROPBEAR_FAILURE;
-	unsigned char * request_addr = NULL;
+	char * request_addr = NULL;
 	unsigned int addrlen;
 	struct TCPListener *tcpinfo = NULL;
 	unsigned int port;
 
 	TRACE(("enter remotetcpreq"))
 
-	request_addr = buf_getstring(ses.payload, &addrlen);
+	request_addr = (char *)buf_getstring(ses.payload, &addrlen);
 	if (addrlen > MAX_IP_LEN) {
 		TRACE(("addr len too long: %d", addrlen))
 		goto out;
@@ -232,12 +232,12 @@ const struct ChanType svr_chan_tcpdirect = {
  * address */
 static int newtcpdirect(struct Channel * channel) {
 
-	unsigned char* desthost = NULL;
+	char* desthost = NULL;
 	unsigned int destport;
-	unsigned char* orighost = NULL;
+	char* orighost = NULL;
 	unsigned int origport;
 	char portstring[NI_MAXSERV];
-	int len;
+	unsigned int len;
 	int err = SSH_OPEN_ADMINISTRATIVELY_PROHIBITED;
 
 	TRACE(("newtcpdirect channel %d", channel->index))
@@ -247,7 +247,7 @@ static int newtcpdirect(struct Channel * channel) {
 		goto out;
 	}
 
-	desthost = buf_getstring(ses.payload, &len);
+	desthost = (char *)buf_getstring(ses.payload, &len);
 	if (len > MAX_HOST_LEN) {
 		TRACE(("leave newtcpdirect: desthost too long"))
 		goto out;
@@ -255,7 +255,7 @@ static int newtcpdirect(struct Channel * channel) {
 
 	destport = buf_getint(ses.payload);
 	
-	orighost = buf_getstring(ses.payload, &len);
+	orighost = (char *)buf_getstring(ses.payload, &len);
 	if (len > MAX_HOST_LEN) {
 		TRACE(("leave newtcpdirect: orighost too long"))
 		goto out;

--- a/svr-x11fwd.c
+++ b/svr-x11fwd.c
@@ -58,8 +58,8 @@ int x11req(struct ChanSess * chansess) {
 	}
 
 	chansess->x11singleconn = buf_getbool(ses.payload);
-	chansess->x11authprot = buf_getstring(ses.payload, NULL);
-	chansess->x11authcookie = buf_getstring(ses.payload, NULL);
+	chansess->x11authprot = (char *)buf_getstring(ses.payload, NULL);
+	chansess->x11authcookie = (char *)buf_getstring(ses.payload, NULL);
 	chansess->x11screennum = buf_getint(ses.payload);
 
 	/* create listening socket */
@@ -107,7 +107,7 @@ static void x11accept(struct Listener* listener, int sock) {
 
 	int fd;
 	struct sockaddr_in addr;
-	int len;
+	socklen_t len;
 	int ret;
 	struct ChanSess * chansess = (struct ChanSess *)(listener->typedata);
 
@@ -203,7 +203,7 @@ static int send_msg_channel_open_x11(int fd, struct sockaddr_in* addr) {
 
 	if (send_msg_channel_open_init(fd, &chan_x11) == DROPBEAR_SUCCESS) {
 		ipstring = inet_ntoa(addr->sin_addr);
-		buf_putstring(ses.writepayload, ipstring, strlen(ipstring));
+		buf_putstring(ses.writepayload, (const unsigned char *)ipstring, strlen(ipstring));
 		buf_putint(ses.writepayload, addr->sin_port);
 
 		encrypt_packet();

--- a/tcp-accept.c
+++ b/tcp-accept.c
@@ -75,7 +75,7 @@ static void tcp_acceptor(struct Listener *listener, int sock) {
 	}
 
 	if (send_msg_channel_open_init(fd, tcpinfo->chantype) == DROPBEAR_SUCCESS) {
-		unsigned char* addr = NULL;
+		char* addr = NULL;
 		unsigned int port = 0;
 
 		if (tcpinfo->tcp_type == direct) {
@@ -94,11 +94,11 @@ static void tcp_acceptor(struct Listener *listener, int sock) {
 		if (addr == NULL) {
 			addr = "localhost";
 		}
-		buf_putstring(ses.writepayload, addr, strlen(addr));
+		buf_putstring(ses.writepayload, (const unsigned char *)addr, strlen(addr));
 		buf_putint(ses.writepayload, port);
 
 		/* originator ip */
-		buf_putstring(ses.writepayload, ipstring, strlen(ipstring));
+		buf_putstring(ses.writepayload, (const unsigned char *)ipstring, strlen(ipstring));
 		/* originator port */
 		buf_putint(ses.writepayload, atol(portstring));
 

--- a/tcpfwd.h
+++ b/tcpfwd.h
@@ -31,16 +31,16 @@ struct TCPListener {
 
 	/* For a direct-tcpip request, it's the addr/port we want the other
 	 * end to connect to */
-	unsigned char *sendaddr;
+	char *sendaddr;
 	unsigned int sendport;
 
 	/* This is the address/port that we listen on. The address has special
 	 * meanings as per the rfc, "" for all interfaces, "localhost" for 
 	 * localhost, or a normal interface name. */
-	unsigned char *listenaddr;
+	char *listenaddr;
 	unsigned int listenport;
 	/* The address that the remote host asked to listen on */
-	unsigned char *request_listenaddr;
+	char *request_listenaddr;
 
 	const struct ChanType *chantype;
 	enum {direct, forwarded} tcp_type;
@@ -48,9 +48,9 @@ struct TCPListener {
 
 /* A forwarding entry */
 struct TCPFwdEntry {
-	const unsigned char* connectaddr;
+	const char *connectaddr;
 	unsigned int connectport;
-	const unsigned char* listenaddr;
+	const char *listenaddr;
 	unsigned int listenport;
 	unsigned int have_reply; /* is set to 1 after a reply has been received
 								when setting up the forwarding */


### PR DESCRIPTION
Hi,

Here are (lots) of patches to make warning disappears from your project :)

The patch-set can be split into two "series", to help you to read all the changes:
- the first six patches fixes trivial warnings such as *unused-parameters*, *unused-function*, *unused-but-set-variable*...
- the second series fixes more tricky *pointer-sign* warnings. All changes are commit separately for readability: they mainly concern the buffer API and the conflicts between c-string/data (ie. signed/unsigned char *).

It is now safe to run:
```
$ ./configure CFLAGS="-Wall -Wextra -Werror" && make
```

I have tested them against *x86-64* and *ARM* with *GCC* and I fixed all warnings I got. The output result looks nicer without any warnings :D. 

Many warnings may still resist depending of the configuration. I have not sanitized yet the extra programs (*scp*...). 

Hope you will be interested in my patches even if they do no bring something new.

Best regards,
Gaël PORTAY