### PR TITLE
Added missing Short-Description init info field to debian init script.

### DIFF
--- a/debian/dropbear.init
+++ b/debian/dropbear.init
@@ -5,6 +5,7 @@
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
+# Short-Description: Dropbear SSH server
 ### END INIT INFO
 #
 # Do not configure this file. Edit /etc/default/dropbear instead!


### PR DESCRIPTION
systemd's systemd-sysv-generator uses some of the [init info](http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/initscrcomconv.html) block at the top of the init script, 'Short-Description' being one of them. Since Dropbear is missing this field, systemd displays 'null' in a bunch of places i.e:
```
● dropbear.service - (null)
   Loaded: loaded (/etc/init.d/dropbear)
   Active: active (running) since Sun 2016-01-03 15:02:36 UTC; 8s ago
     Docs: man:systemd-sysv-generator(8)
Jan 03 15:02:36 wily systemd[1]: Starting (null)...
Jan 03 15:02:36 wily dropbear[486]: Failed loading /etc/dropbear/dropbear_ecdsa_host_key
Jan 03 15:02:36 wily dropbear[487]: Running in background
Jan 03 15:02:36 wily systemd[1]: Started (null).
```

And with the extra field:
```
● dropbear.service - LSB: Dropbear SSH server
   Loaded: loaded (/etc/init.d/dropbear)
   Active: active (running) since Sun 2016-01-03 15:06:20 UTC; 4s ago
     Docs: man:systemd-sysv-generator(8)
  Process: 515 ExecStop=/etc/init.d/dropbear stop (code=exited, status=0/SUCCESS)
  Process: 517 ExecStart=/etc/init.d/dropbear start (code=exited, status=0/SUCCESS)
   CGroup: /machine.slice/machine-wily\x2dtree.scope/system.slice/dropbear.service
           └─519 /usr/sbin/dropbear -d /etc/dropbear/dropbear_dss_host_key -r /etc/dropbear/dropbear_rsa_host_key -p ...

Jan 03 15:06:20 wily systemd[1]: Starting LSB: Dropbear SSH server...
Jan 03 15:06:20 wily dropbear[518]: Failed loading /etc/dropbear/dropbear_ecdsa_host_key
Jan 03 15:06:20 wily dropbear[519]: Running in background
Jan 03 15:06:20 wily systemd[1]: Started LSB: Dropbear SSH server.
```