### PR TITLE
Support out-of-tree builds usign bundled libtom

### DIFF
--- a/libtomcrypt/Makefile.in
+++ b/libtomcrypt/Makefile.in
@@ -19,7 +19,7 @@ srcdir=@srcdir@
 
 # Compilation flags. Note the += does not write over the user's CFLAGS!
 # The rest of the flags come from the parent Dropbear makefile
-CFLAGS += -c -I$(srcdir)/src/headers/ -I$(srcdir)/../ -DLTC_SOURCE -I$(srcdir)/../libtommath/
+CFLAGS += -c -Isrc/headers/ -I$(srcdir)/src/headers/ -I../ -I$(srcdir)/../ -DLTC_SOURCE -I../libtommath/ -I$(srcdir)/../libtommath/
 
 # additional warnings (newer GCC 3.4 and higher)
 ifdef GCC_34

--- a/libtommath/Makefile.in
+++ b/libtommath/Makefile.in
@@ -9,7 +9,7 @@ VPATH=@srcdir@
 srcdir=@srcdir@
 
 # So that libtommath can include Dropbear headers for options and m_burn()
-CFLAGS += -I$(srcdir)/../libtomcrypt/src/headers/ -I$(srcdir)/../
+CFLAGS += -I. -I$(srcdir) -I../libtomcrypt/src/headers/ -I$(srcdir)/../libtomcrypt/src/headers/ -I../ -I$(srcdir)/../
 
 ifndef IGNORE_SPEED
 


### PR DESCRIPTION
When building out-of-tree we need both source and generated
folders in include paths to find both distributed and generated
headers.