### PR TITLE
Use DROPBEAR_PATH_DEVNULL instead of undefined _PATH_DEVNULL

### DIFF
--- a/cli-session.c
+++ b/cli-session.c
@@ -287,7 +287,7 @@ static void cli_sessionloop() {
 				int devnull;
 				/* keeping stdin open steals input from the terminal and
 				   is confusing, though stdout/stderr could be useful. */
-				devnull = open(_PATH_DEVNULL, O_RDONLY);
+				devnull = open(DROPBEAR_PATH_DEVNULL, O_RDONLY);
 				if (devnull < 0) {
 					dropbear_exit("Opening /dev/null: %d %s",
 							errno, strerror(errno));

--- a/compat.c
+++ b/compat.c
@@ -177,7 +177,7 @@ int daemon(int nochdir, int noclose) {
 	if (!nochdir)
 		(void)chdir("/");
 
-	if (!noclose && (fd = open(_PATH_DEVNULL, O_RDWR, 0)) != -1) {
+	if (!noclose && (fd = open(DROPBEAR_PATH_DEVNULL, O_RDWR, 0)) != -1) {
 		(void)dup2(fd, STDIN_FILENO);
 		(void)dup2(fd, STDOUT_FILENO);
 		(void)dup2(fd, STDERR_FILENO);

--- a/scpmisc.c
+++ b/scpmisc.c
@@ -235,7 +235,7 @@ sanitise_stdfd(void)
 {
 	int nullfd, dupfd;
 
-	if ((nullfd = dupfd = open(_PATH_DEVNULL, O_RDWR)) == -1) {
+	if ((nullfd = dupfd = open(DROPBEAR_PATH_DEVNULL, O_RDWR)) == -1) {
 		fprintf(stderr, "Couldn't open /dev/null: %s", strerror(errno));
 		exit(1);
 	}


### PR DESCRIPTION
_PATH_DEVNULL isn't defined anywhere and was causing issue when porting to a POSIX-like OS.
