### PR TITLE
dropbear server: support -T max auth tries

### DIFF
--- a/default_options.h
+++ b/default_options.h
@@ -385,6 +385,12 @@ Homedir is prepended unless path begins with / */
 #define MAX_AUTH_TRIES 10
 #endif
 
+/* Default maximum number of failed authentication tries.
+ * defaults to MAX_AUTH_TRIES */
+#ifndef DEFAULT_AUTH_TRIES
+#define DEFAULT_AUTH_TRIES MAX_AUTH_TRIES
+#endif
+
 /* The default file to store the daemon's process ID, for shutdown
    scripts etc. This can be overridden with the -P flag */
 #ifndef DROPBEAR_PIDFILE

--- a/default_options.h.in
+++ b/default_options.h.in
@@ -261,6 +261,10 @@ Homedir is prepended unless path begins with / */
 /* Maximum number of failed authentication tries (server option) */
 #define MAX_AUTH_TRIES 10
 
+/* Default maximum number of failed authentication tries.
+ * defaults to MAX_AUTH_TRIES */
+#define DEFAULT_AUTH_TRIES MAX_AUTH_TRIES
+
 /* The default file to store the daemon's process ID, for shutdown
    scripts etc. This can be overridden with the -P flag */
 #define DROPBEAR_PIDFILE "/var/run/dropbear.pid"

--- a/dropbear.8
+++ b/dropbear.8
@@ -91,6 +91,9 @@ if 0 disables keepalives. If no response is received for 3 consecutive keepalive
 .B \-I \fIidle_timeout
 Disconnect the session if no traffic is transmitted or received for \fIidle_timeout\fR seconds.
 .TP
+.B \-T \fImax_authentication_attempts
+Disconnect the session if number of authentication attempts is exceeded. default is set at compile time to DEFAULT_AUTH_TRIES which itself defaults to MAX_AUTH_TRIES (10)
+.TP
 .B \-c \fIforced_command
 Disregard the command provided by the user and always run \fIforced_command\fR. This also
 overrides any authorized_keys command= option.

--- a/runopts.h
+++ b/runopts.h
@@ -96,6 +96,7 @@ typedef struct svr_runopts {
 	int noauthpass;
 	int norootpass;
 	int allowblankpass;
+	unsigned int maxauthtries;
 
 #if DROPBEAR_SVR_REMOTETCPFWD
 	int noremotetcp;

--- a/svr-auth.c
+++ b/svr-auth.c
@@ -362,7 +362,7 @@ void send_msg_userauth_failure(int partial, int incrfail) {
 		ses.authstate.failcount++;
 	}
 
-	if (ses.authstate.failcount >= MAX_AUTH_TRIES) {
+	if (ses.authstate.failcount >= svr_opts.maxauthtries) {
 		char * userstr;
 		/* XXX - send disconnect ? */
 		TRACE(("Max auth tries reached, exiting"))

--- a/svr-runopts.c
+++ b/svr-runopts.c
@@ -73,6 +73,7 @@ static void printhelp(const char * progname) {
 					"-g		Disable password logins for root\n"
 					"-B		Allow blank password logins\n"
 #endif
+					"-T <1 to %d> 	Maximum authentication tries (default %d)\n"
 #if DROPBEAR_SVR_LOCALTCPFWD
 					"-j		Disable local port forwarding\n"
 #endif
@@ -107,6 +108,7 @@ static void printhelp(const char * progname) {
 #if DROPBEAR_ECDSA
 					ECDSA_PRIV_FILENAME,
 #endif
+					MAX_AUTH_TRIES, DEFAULT_AUTH_TRIES,
 					DROPBEAR_MAX_PORTS, DROPBEAR_DEFPORT, DROPBEAR_PIDFILE,
 					DEFAULT_RECV_WINDOW, DEFAULT_KEEPALIVE, DEFAULT_IDLE_TIMEOUT);
 }
@@ -119,6 +121,7 @@ void svr_getopts(int argc, char ** argv) {
 	char* recv_window_arg = NULL;
 	char* keepalive_arg = NULL;
 	char* idle_timeout_arg = NULL;
+	char* maxauthtries_arg = NULL;
 	char* keyfile = NULL;
 	char c;
 
@@ -132,6 +135,7 @@ void svr_getopts(int argc, char ** argv) {
 	svr_opts.noauthpass = 0;
 	svr_opts.norootpass = 0;
 	svr_opts.allowblankpass = 0;
+	svr_opts.maxauthtries = DEFAULT_AUTH_TRIES;
 	svr_opts.inetdmode = 0;
 	svr_opts.portcount = 0;
 	svr_opts.hostkey = NULL;
@@ -235,6 +239,9 @@ void svr_getopts(int argc, char ** argv) {
 				case 'I':
 					next = &idle_timeout_arg;
 					break;
+				case 'T':
+					next = &maxauthtries_arg;
+					break;
 #if DROPBEAR_SVR_PASSWORD_AUTH || DROPBEAR_SVR_PAM_AUTH
 				case 's':
 					svr_opts.noauthpass = 1;
@@ -331,6 +338,16 @@ void svr_getopts(int argc, char ** argv) {
 			dropbear_exit("Bad recv window '%s'", recv_window_arg);
 		}
 	}
+
+	if (maxauthtries_arg) {
+		unsigned int val = 0;
+		if (m_str_to_uint(maxauthtries_arg, &val) == DROPBEAR_FAILURE ||
+			val == 0 || val > MAX_AUTH_TRIES) {
+			dropbear_exit("Bad maxauthtries '%s'", maxauthtries_arg);
+		}
+		svr_opts.maxauthtries = val;
+	}
+
 	
 	if (keepalive_arg) {
 		unsigned int val;


### PR DESCRIPTION
Add support for '-T n' for a run-time specification for maximum number
of authentication attempts where 'n' is between 1 and compile time
option MAX_AUTH_TRIES.

A default number of tries can be specified at compile time using
'DEFAULT_AUTH_TRIES' which itself defaults to MAX_AUTH_TRIES for
backwards compatibility.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>