### PR TITLE
dropbear: Reset the pam counters after succefully logging in

### DIFF
--- a/svr-authpam.c
+++ b/svr-authpam.c
@@ -263,6 +263,8 @@ void svr_auth_pam() {
 	dropbear_log(LOG_NOTICE, "PAM password auth succeeded for '%s' from %s",
 			ses.authstate.pw_name,
 			svr_ses.addrstring);
+	/* reset the pam counter on a successful attempt */
+	pam_setcred(pamHandlep, PAM_ESTABLISH_CRED);
 	send_msg_userauth_success();
 
 cleanup:


### PR DESCRIPTION
Per the pam manual, the user app that is using the pam module,
is the one that should reset the pam counters(tally/tally2).
This fixes cases where dropbear was used to ssh on pam enabled
systems.