### PR TITLE
Correctly return pubkey auth status

### DIFF
--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -361,8 +361,8 @@ static int checkpubkey(char* algo, unsigned int algolen,
 		}
 		line_num++;
 
-		if (checkpubkey_line(line, line_num, filename,
-				algo, algolen, keyblob, keybloblen) == DROPBEAR_SUCCESS) {
+		if ((ret = checkpubkey_line(line, line_num, filename,
+				algo, algolen, keyblob, keybloblen)) == DROPBEAR_SUCCESS) {
 			break;
 		}
 


### PR DESCRIPTION
A prior commit (6e0b539e9ca0b5628c6c5a3d118ad6a2e79e8039) stopped the success value from being set