### PR TITLE
Add Spectre v2 mitigations for GCC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,11 @@ if test "$hardenbuild" -eq 1; then
 	    )
 	# FORTIFY_SOURCE
 	DB_TRYADDCFLAGS([-D_FORTIFY_SOURCE=2])
+
+	# Spectre v2 mitigations
+	DB_TRYADDCFLAGS([-mfunction-return=thunk])
+	DB_TRYADDCFLAGS([-mindirect-branch=thunk])
+
 fi
 
 # large file support is useful for scp


### PR DESCRIPTION
Add mitigations for Spectre v2 attacks.

Spectre:
https://googleprojectzero.blogspot.com/2018/01/reading-privileged-memory-with-side.html

