### PR TITLE
Added the -G option to allow logins only for users that are members o…

### DIFF
--- a/runopts.h
+++ b/runopts.h
@@ -92,6 +92,8 @@ typedef struct svr_runopts {
 #endif
 
 	int norootlogin;
+        char *grouploginname;
+        gid_t *grouploginid;
 
 	int noauthpass;
 	int norootpass;


### PR DESCRIPTION
…f a certain group. This allows finer control of an instance on who can and cannot login over a certain instance (e.g. password and not key). Needs double-checking and ensuring it meets platform requirements.

I'm not used to writing code in a security-critical environment or writing in C (I'm C++ really) so please check with caution! I've tried to be as defensive as possible. Also might need some adjustments for different platforms, I just developed it on Linux.

Thanks!