### PR TITLE
packet: remove stale comment about "packet_type"

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -110,8 +110,6 @@ void write_packet() {
 	/* Get the next buffer in the queue of encrypted packets to write*/
 	writebuf = (buffer*)examine(&ses.writequeue);
 
-	/* The last byte of the buffer is not to be transmitted, but is 
-	 * a cleartext packet_type indicator */
 	len = writebuf->len - writebuf->pos;
 	dropbear_assert(len > 0);
 	/* Try to write as much as possible */


### PR DESCRIPTION
clean up after 7f15910541

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>