### PR TITLE
cygwin competibility fix

### DIFF
--- a/netio.c
+++ b/netio.c
@@ -298,7 +298,11 @@ void packet_queue_to_iovec(const struct Queue *queue, struct iovec *iov, unsigne
 	buffer *writebuf;
 
 	#ifndef IOV_MAX
-	#define IOV_MAX UIO_MAXIOV
+		#if defined(__CYGWIN__) && !defined(UIO_MAXIOV)
+		#define IOV_MAX 1024
+		#else
+		#define IOV_MAX UIO_MAXIOV
+		#endif
 	#endif
 
 	*iov_count = MIN(MIN(queue->count, IOV_MAX), *iov_count);

--- a/packet.c
+++ b/packet.c
@@ -58,7 +58,7 @@ static void buf_compress(buffer * dest, buffer * src, unsigned int len);
 void write_packet() {
 
 	ssize_t written;
-#ifdef HAVE_WRITEV
+#if defined(HAVE_WRITEV) && (defined(IOV_MAX) || defined(UIO_MAXIOV))
 	/* 50 is somewhat arbitrary */
 	unsigned int iov_count = 50;
 	struct iovec iov[50];


### PR DESCRIPTION
Ad `packet.c` - basically just aligning two #ifdefs - see also https://stackoverflow.com/questions/49187521/packet-c982-error-writebuf-undeclared-first-use-in-this-function

Ad `netio.c` - IOV_MAX is not available in cygwin unless you define _XOPEN_SOURCE to proper value (which has other side effects)