### PR TITLE
dropbearconvert: keyimport.c: fix BER encoding of secp521r1 keys

### DIFF
--- a/keyimport.c
+++ b/keyimport.c
@@ -1097,7 +1097,9 @@ static int openssh_write(const char *filename, sign_key *key,
 		buf_putbytes(seq_buf, curve_oid, curve_oid_len);
 
 		buf_incrwritepos(seq_buf,
-			ber_write_id_len(buf_getwriteptr(seq_buf, 10), 1, 2+1+pubkey_size, 0xa0));
+			ber_write_id_len(buf_getwriteptr(seq_buf, 10), 1,
+			(pubkey_size +1 < 128 ? 2 : 3 ) +1 +pubkey_size, 0xa0));
+
 		buf_incrwritepos(seq_buf,
 			ber_write_id_len(buf_getwriteptr(seq_buf, 10), 3, 1+pubkey_size, 0));
 		buf_putbyte(seq_buf, 0);


### PR DESCRIPTION
keysizes >= 128 octets will be encoded with a 3 byte header
which must be accounted by the optional-header

Reproduce:

master:~/build/dropbear$ ./dropbearkey -t ecdsa -s 521 -f K
Generating 521 bit ecdsa key, this may take a while...

master:~/build/dropbear$ ./dropbearconvert d o K L
Key is a ecdsa-sha2-nistp521 key
Wrote key to 'L'

master:~/build/dropbear$ openssl ec < L
read EC key
unable to load Key
139769806448384:error:0D07209B:asn1 encoding routines:ASN1_get_object:too long:crypto/asn1/asn1_lib.c:91: