### PR TITLE
External Public-Key Authentication API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.bb
 *.bbg
 *.prof
+.*.swp
 /autom4te.cache
 /config.log
 /config.status

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ config.h
 config.h.in
 configure
 default_options_guard.h
+tags

--- a/Makefile.in
+++ b/Makefile.in
@@ -80,6 +80,12 @@ else
 	scpobjs=$(SCPOBJS)
 endif
 
+ifeq (@DROPBEAR_EPKA@, 1)
+    EPKA_LIBS=-ldl
+else
+    EPKA_LIBS=
+endif
+
 VPATH=@srcdir@
 srcdir=@srcdir@
 
@@ -189,7 +195,7 @@ dropbearkey: $(dropbearkeyobjs)
 dropbearconvert: $(dropbearconvertobjs)
 
 dropbear: $(HEADERS) $(LIBTOM_DEPS) Makefile
-	$(CC) $(LDFLAGS) -o $@$(EXEEXT) $($@objs) $(LIBTOM_LIBS) $(LIBS) @CRYPTLIB@
+	$(CC) $(LDFLAGS) -o $@$(EXEEXT) $($@objs) $(LIBTOM_LIBS) $(LIBS) @CRYPTLIB@ $(EPKA_LIBS)
 
 dbclient: $(HEADERS) $(LIBTOM_DEPS) Makefile
 	$(CC) $(LDFLAGS) -o $@$(EXEEXT) $($@objs) $(LIBTOM_LIBS) $(LIBS)

--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,10 @@ else
 endif
 
 ifeq (@DROPBEAR_EPKA@, 1)
-    EPKA_LIBS=-ldl
+    # rdynamic makes all the global symbols of dropbear available to all the loaded shared libraries
+    # this allow a plugin to reuse existing crypto/utilities like base64_decode/base64_encode without
+    # the need to rewrite them.
+    EPKA_LIBS=-ldl -rdynamic
 else
     EPKA_LIBS=
 endif

--- a/common-session.c
+++ b/common-session.c
@@ -137,6 +137,10 @@ void common_session_init(int sock_in, int sock_out) {
 
 	ses.allowprivport = 0;
 
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+        ses.pubkey_plugin_session = NULL;
+#endif
+
 	TRACE(("leave session_init"))
 }
 

--- a/common-session.c
+++ b/common-session.c
@@ -137,7 +137,7 @@ void common_session_init(int sock_in, int sock_out) {
 
 	ses.allowprivport = 0;
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         ses.pubkey_plugin_session = NULL;
 #endif
 

--- a/common-session.c
+++ b/common-session.c
@@ -138,7 +138,7 @@ void common_session_init(int sock_in, int sock_out) {
 	ses.allowprivport = 0;
 
 #if DROPBEAR_EPKA
-        ses.pubkey_plugin_session = NULL;
+        ses.epka_session = NULL;
 #endif
 
 	TRACE(("leave session_init"))

--- a/configure.ac
+++ b/configure.ac
@@ -323,6 +323,21 @@ AC_ARG_ENABLE(shadow,
 	]
 )
 
+AC_ARG_ENABLE(epka,
+	[  --enable-epka           Enable support for External Public Key Authentication plug-in],
+	[
+		AC_DEFINE(DROPBEAR_EPKA, 1, External Public Key Authentication)
+		AC_MSG_NOTICE(Enabling support for External Public Key Authentication)
+		DROPBEAR_EPKA=1
+	],
+	[
+		AC_DEFINE(DROPBEAR_EPKA, 0, External Public Key Authentication)
+		DROPBEAR_EPKA=0
+	]
+
+)
+AC_SUBST(DROPBEAR_EPKA)
+
 AC_ARG_ENABLE(fuzz,
 	[  --enable-fuzz           Build fuzzing. Not recommended for deployment.],
 	[

--- a/default_options.h
+++ b/default_options.h
@@ -192,6 +192,13 @@ group1 in Dropbear server too */
 /* ~/.ssh/authorized_keys authentication */
 #define DROPBEAR_SVR_PUBKEY_AUTH 1
 
+/* Enable external plug-in loading for public key authentication.
+ * Requires DROPBEAR_SVR_PUBKEY_AUTH to be set
+ * server only.
+ */
+#define DROPBEAR_SVR_PUBKEY_EXTPLUGIN    1
+
+
 /* Whether to take public key options in 
  * authorized_keys file into account */
 #define DROPBEAR_SVR_PUBKEY_OPTIONS 1

--- a/default_options.h
+++ b/default_options.h
@@ -192,13 +192,6 @@ group1 in Dropbear server too */
 /* ~/.ssh/authorized_keys authentication */
 #define DROPBEAR_SVR_PUBKEY_AUTH 1
 
-/* Enable external plug-in loading for public key authentication.
- * Requires DROPBEAR_SVR_PUBKEY_AUTH to be set
- * server only.
- */
-#define DROPBEAR_SVR_PUBKEY_EXTPLUGIN    1
-
-
 /* Whether to take public key options in 
  * authorized_keys file into account */
 #define DROPBEAR_SVR_PUBKEY_OPTIONS 1

--- a/includes.h
+++ b/includes.h
@@ -164,6 +164,10 @@ typedef u_int32_t uint32_t;
 #include <linux/pkt_sched.h>
 #endif
 
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#include <dlfcn.h>
+#endif
+
 #include "fake-rfc2553.h"
 
 #include "fuzz.h"

--- a/includes.h
+++ b/includes.h
@@ -164,7 +164,7 @@ typedef u_int32_t uint32_t;
 #include <linux/pkt_sched.h>
 #endif
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
 #include <dlfcn.h>
 #endif
 

--- a/pubkeyapi.h
+++ b/pubkeyapi.h
@@ -63,11 +63,14 @@ struct EPKASession;
  * If plugin_MINOR < dropbeart_MINOR or if the MAJOR version is different
  * dropbear will reject the plugin and terminate the execution.
  *
+ * addrstring is the IP address of the client.
+ *
  * Returns NULL in case of failure, otherwise a void * of the instance that need
  * to be passed to all the subsequent call to the plugin
  */
 typedef struct EPKAInstance *(* PubkeyExtPlugin_newFn)(int verbose, 
-        const char *options);
+        const char *options,
+        const char *addrstring);
 #define DROPBEAR_PUBKEY_PLUGIN_FNNAME_NEW               "plugin_new"
 
 

--- a/pubkeyapi.h
+++ b/pubkeyapi.h
@@ -122,6 +122,16 @@ struct EPKAInstance {
     PubkeyExtPlugin_deleteFn        delete_plugin;          /* mandatory */
 };
 
+/*****************************************************************************
+ * SESSION
+ ****************************************************************************/
+/* Returns the options from the session. 
+ * The returned buffer will be destroyed when the session is deleted.
+ * Option buffer string NULL-terminated
+ */
+typedef unsigned char * (* PubkeyExtPlugin_getOptionsFn)(struct EPKASession *session);
+
+
 /* An SSH Session. Created during pre-auth and reused during the authentication.
  * The plug-in should delete this object (or any object extending it) from 
  * the delete_session() function.
@@ -135,8 +145,7 @@ struct EPKAInstance {
 struct EPKASession {
     struct EPKAInstance *  plugin_instance;
 
-    unsigned char * auth_options;                           /* Set to NULL if no options are provided */
-    unsigned int    auth_options_length;
+    PubkeyExtPlugin_getOptionsFn   get_options;
 };
 
 #endif

--- a/pubkeyapi.h
+++ b/pubkeyapi.h
@@ -55,10 +55,16 @@ typedef struct EPKAInstance *(* PubkeyExtPlugin_newFn)(int verbose,
 
 
 /* Validate a client through public key authentication
- * Returns a new session (opaque pointer to be destroyed when session ends)
- * or NULL in case of authentication failure.
+ *
+ * If session has not been already created, creates it and store it 
+ * in *sessionInOut.
+ * If session is a non-NULL, it will reuse it.
+ *
+ * Returns DROPBEAR_SUCCESS (0) if success or DROPBEAR_FAILURE (-1) if
+ * authentication fails
  */
-typedef struct EPKASession * (* PubkeyExtPlugin_checkPubKeyFn)(struct EPKAInstance *pluginInstance,
+typedef int (* PubkeyExtPlugin_checkPubKeyFn)(struct EPKAInstance *pluginInstance,
+        struct EPKASession **sessionInOut,
         const char* algo, 
         unsigned int algolen,
         const unsigned char* keyblob, 

--- a/pubkeyapi.h
+++ b/pubkeyapi.h
@@ -129,7 +129,7 @@ struct EPKAInstance {
  * The returned buffer will be destroyed when the session is deleted.
  * Option buffer string NULL-terminated
  */
-typedef unsigned char * (* PubkeyExtPlugin_getOptionsFn)(struct EPKASession *session);
+typedef char * (* PubkeyExtPlugin_getOptionsFn)(struct EPKASession *session);
 
 
 /* An SSH Session. Created during pre-auth and reused during the authentication.

--- a/pubkeyapi.h
+++ b/pubkeyapi.h
@@ -1,0 +1,68 @@
+/*
+ * Dropbear - a SSH2 server
+ * 
+ * Copyright (c) 2002,2003 Matt Johnston
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE. */
+#ifndef DROPBEAR_PUBKEY_H
+#define DROPBEAR_PUBKEY_H
+
+
+/* Function API */
+
+/* Creates an instance
+ * Returns NULL in case of failure, otherwise a void * of the instance that need
+ * to be passed to all the subsequent call to the plugin
+ */
+typedef void *(* PubkeyExtPlugin_newFn)(int verbose, 
+        const char *options);
+#define DROPBEAR_PUBKEY_PLUGIN_FNNAME_NEW               "plugin_new"
+
+
+/* Validate a client through public key authentication
+ * Returns a new session (opaque pointer to be destroyed when session ends)
+ * or NULL in case of authentication failure.
+ *
+ * TODO: Have a way to pass options to the caller
+ */
+typedef void * (* PubkeyExtPlugin_checkPubKeyFn)(void *pluginInstance, 
+        const char* algo, 
+        unsigned int algolen,
+        const unsigned char* keyblob, 
+        unsigned int keybloblen);
+#define DROPBEAR_PUBKEY_PLUGIN_FNNAME_CHECKPUBKEY       "plugin_checkpubkey"
+
+/* Notify the plugin that auth completed (after signature verification)
+ */
+typedef void (* PubkeyExtPlugin_authSuccessFn)(void *pluginInstance, void *sessionInstance);
+#define DROPBEAR_PUBKEY_PLUGIN_FNNAME_AUTHSUCCESS       "plugin_auth_success"
+
+/* Deletes a session
+ * TODO: Add a reason why the session is terminated. See svr_dropbear_exit (in svr-session.c)
+ */
+typedef void (* PubkeyExtPlugin_sessionDeleteFn)(void *pluginInstance,
+        void *pluginSession);
+#define DROPBEAR_PUBKEY_PLUGIN_FNNAME_SESSIONDELETE     "plugin_session_delete"
+
+/* Deletes the plugin instance */
+typedef void (* PubkeyExtPlugin_deleteFn)(void *pluginInstance);
+#define DROPBEAR_PUBKEY_PLUGIN_FNNAME_DELETE            "plugin_delete"
+
+#endif

--- a/runopts.h
+++ b/runopts.h
@@ -125,6 +125,11 @@ typedef struct svr_runopts {
 
 	char * forced_command;
 
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN 
+        char *pubkey_plugin;
+        char *pubkey_plugin_options;
+#endif
+
 } svr_runopts;
 
 extern svr_runopts svr_opts;

--- a/runopts.h
+++ b/runopts.h
@@ -125,7 +125,7 @@ typedef struct svr_runopts {
 
 	char * forced_command;
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN 
+#if DROPBEAR_EPKA 
         char *pubkey_plugin;
         char *pubkey_plugin_options;
 #endif

--- a/session.h
+++ b/session.h
@@ -38,7 +38,7 @@
 #include "chansession.h"
 #include "dbutil.h"
 #include "netio.h"
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
 #include "pubkeyapi.h"
 #endif
 
@@ -220,7 +220,7 @@ struct sshsession {
 	/* set once the ses structure (and cli_ses/svr_ses) have been populated to their initial state */
 	int init_done;
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         void * pubkey_plugin_session;
 #endif
 };
@@ -248,7 +248,7 @@ struct serversession {
 	pid_t server_pid;
 #endif
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         void *pubkey_plugin_handle;
         void *pubkey_plugin_handle_instance;
         /* Resolved when plugin is loaded */

--- a/session.h
+++ b/session.h
@@ -221,7 +221,7 @@ struct sshsession {
 	int init_done;
 
 #if DROPBEAR_EPKA
-        void * pubkey_plugin_session;
+        struct EPKASession * epka_session;
 #endif
 };
 
@@ -249,14 +249,11 @@ struct serversession {
 #endif
 
 #if DROPBEAR_EPKA
-        void *pubkey_plugin_handle;
-        void *pubkey_plugin_handle_instance;
-        /* Resolved when plugin is loaded */
-        PubkeyExtPlugin_newFn           pubkey_plugin_new;
-        PubkeyExtPlugin_checkPubKeyFn   pubkey_plugin_checkPubKey;
-        PubkeyExtPlugin_authSuccessFn   pubkey_plugin_authSuccess;
-        PubkeyExtPlugin_sessionDeleteFn pubkey_plugin_sessionDelete;
-        PubkeyExtPlugin_deleteFn        pubkey_plugin_delete;
+        /* The shared library handle */
+        void *epka_plugin_handle;
+
+        /* The instance created by the plugin_new function */
+        struct EPKAInstance *epka_instance;
 #endif
 
 };

--- a/session.h
+++ b/session.h
@@ -38,6 +38,9 @@
 #include "chansession.h"
 #include "dbutil.h"
 #include "netio.h"
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#include "pubkeyapi.h"
+#endif
 
 void common_session_init(int sock_in, int sock_out);
 void session_loop(void(*loophandler)(void)) ATTRIB_NORETURN;
@@ -216,6 +219,10 @@ struct sshsession {
 	volatile int exitflag;
 	/* set once the ses structure (and cli_ses/svr_ses) have been populated to their initial state */
 	int init_done;
+
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+        void * pubkey_plugin_session;
+#endif
 };
 
 struct serversession {
@@ -239,6 +246,17 @@ struct serversession {
 
 #if DROPBEAR_VFORK
 	pid_t server_pid;
+#endif
+
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+        void *pubkey_plugin_handle;
+        void *pubkey_plugin_handle_instance;
+        /* Resolved when plugin is loaded */
+        PubkeyExtPlugin_newFn           pubkey_plugin_new;
+        PubkeyExtPlugin_checkPubKeyFn   pubkey_plugin_checkPubKey;
+        PubkeyExtPlugin_authSuccessFn   pubkey_plugin_authSuccess;
+        PubkeyExtPlugin_sessionDeleteFn pubkey_plugin_sessionDelete;
+        PubkeyExtPlugin_deleteFn        pubkey_plugin_delete;
 #endif
 
 };

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -113,14 +113,14 @@ void svr_auth_pubkey(int valid_user) {
 	}
 #if DROPBEAR_EPKA
         if (svr_ses.epka_instance != NULL) {
-            ses.epka_session = svr_ses.epka_instance->checkpubkey(
+            if (svr_ses.epka_instance->checkpubkey(
                         svr_ses.epka_instance,
+                        &ses.epka_session,
                         algo, 
                         algolen, 
                         keyblob, 
                         keybloblen,
-                        ses.authstate.username);
-            if (ses.epka_session != NULL) {
+                        ses.authstate.username) == DROPBEAR_SUCCESS) {
                 /* Success */
                 auth_failure = 0;
 

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -113,6 +113,7 @@ void svr_auth_pubkey(int valid_user) {
 	}
 #if DROPBEAR_EPKA
         if (svr_ses.epka_instance != NULL) {
+            unsigned char *options_buf;
             if (svr_ses.epka_instance->checkpubkey(
                         svr_ses.epka_instance,
                         &ses.epka_session,
@@ -125,10 +126,11 @@ void svr_auth_pubkey(int valid_user) {
                 auth_failure = 0;
 
                 /* Options provided? */
-                if (ses.epka_session->auth_options != NULL) {
+                options_buf = ses.epka_session->get_options(ses.epka_session);
+                if (options_buf) {
                     struct buf temp_buf = { 
-                        .data = ses.epka_session->auth_options,
-                        .len = ses.epka_session->auth_options_length,
+                        .data = options_buf,
+                        .len = strlen(options_buf),
                         .pos = 0,
                         .size = 0
                     };

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -111,7 +111,7 @@ void svr_auth_pubkey(int valid_user) {
 		send_msg_userauth_failure(0, 0);
 		goto out;
 	}
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         if ((svr_ses.pubkey_plugin_handle != NULL) && (svr_ses.pubkey_plugin_handle_instance != NULL)) {
             ses.pubkey_plugin_session = svr_ses.pubkey_plugin_checkPubKey(
                         svr_ses.pubkey_plugin_handle_instance,
@@ -171,7 +171,7 @@ void svr_auth_pubkey(int valid_user) {
 				"Pubkey auth succeeded for '%s' with key %s from %s",
 				ses.authstate.pw_name, fp, svr_ses.addrstring);
 		send_msg_userauth_success();
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
                 if ((svr_ses.pubkey_plugin_handle != NULL) && (ses.pubkey_plugin_session != NULL)) {
                     /* Was authenticated through the external plugin. tell plugin that signature verification was ok */
                     svr_ses.pubkey_plugin_authSuccess(svr_ses.pubkey_plugin_handle, ses.pubkey_plugin_session);

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -113,7 +113,7 @@ void svr_auth_pubkey(int valid_user) {
 	}
 #if DROPBEAR_EPKA
         if (svr_ses.epka_instance != NULL) {
-            unsigned char *options_buf;
+            char *options_buf;
             if (svr_ses.epka_instance->checkpubkey(
                         svr_ses.epka_instance,
                         &ses.epka_session,
@@ -129,7 +129,7 @@ void svr_auth_pubkey(int valid_user) {
                 options_buf = ses.epka_session->get_options(ses.epka_session);
                 if (options_buf) {
                     struct buf temp_buf = { 
-                        .data = options_buf,
+                        .data = (unsigned char *)options_buf,
                         .len = strlen(options_buf),
                         .pos = 0,
                         .size = 0

--- a/svr-runopts.c
+++ b/svr-runopts.c
@@ -413,8 +413,10 @@ void svr_getopts(int argc, char ** argv) {
 #if DROPBEAR_EPKA
         if (pubkey_plugin) {
             char *args = strchr(pubkey_plugin, ',');
-            if (args) *args='\0';
-            ++args;
+            if (args) {
+                *args='\0';
+                ++args;
+            }
             svr_opts.pubkey_plugin = pubkey_plugin;
             svr_opts.pubkey_plugin_options = args;
         }

--- a/svr-runopts.c
+++ b/svr-runopts.c
@@ -100,6 +100,10 @@ static void printhelp(const char * progname) {
 					"-K <keepalive>  (0 is never, default %d, in seconds)\n"
 					"-I <idle_timeout>  (0 is never, default %d, in seconds)\n"
 					"-V    Version\n"
+#if DROPBEAR_ENABLE_PUBKEY_EXTPLUGIN
+                                        "-A <authplugin>[,<options>]\n"
+                                        "               Enable external public key auth through <authplugin>\n"
+#endif
 #if DEBUG_TRACE
 					"-v		verbose (compiled with DEBUG_TRACE)\n"
 #endif
@@ -129,6 +133,9 @@ void svr_getopts(int argc, char ** argv) {
 	char* maxauthtries_arg = NULL;
 	char* keyfile = NULL;
 	char c;
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+        char* pubkey_plugin = NULL;
+#endif
 
 
 	/* see printhelp() for options */
@@ -155,6 +162,10 @@ void svr_getopts(int argc, char ** argv) {
 #endif
 #if DROPBEAR_SVR_REMOTETCPFWD
 	svr_opts.noremotetcp = 0;
+#endif
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+        svr_opts.pubkey_plugin = NULL;
+        svr_opts.pubkey_plugin_options = NULL;
 #endif
 
 #ifndef DISABLE_ZLIB
@@ -274,6 +285,11 @@ void svr_getopts(int argc, char ** argv) {
 				case 'u':
 					/* backwards compatibility with old urandom option */
 					break;
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+                                case 'A':
+                                        next = &pubkey_plugin;
+                                        break;
+#endif
 #if DEBUG_TRACE
 				case 'v':
 					debug_trace = 1;
@@ -394,6 +410,15 @@ void svr_getopts(int argc, char ** argv) {
 	if (svr_opts.forced_command) {
 		dropbear_log(LOG_INFO, "Forced command set to '%s'", svr_opts.forced_command);
 	}
+#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+        if (pubkey_plugin) {
+            char *args = strchr(pubkey_plugin, ',');
+            if (args) *args='\0';
+            ++args;
+            svr_opts.pubkey_plugin = pubkey_plugin;
+            svr_opts.pubkey_plugin_options = args;
+        }
+#endif
 }
 
 static void addportandaddress(const char* spec) {

--- a/svr-runopts.c
+++ b/svr-runopts.c
@@ -46,16 +46,16 @@ static void printhelp(const char * progname) {
 					"-b bannerfile	Display the contents of bannerfile"
 					" before user login\n"
 					"		(default: none)\n"
-					"-r keyfile  Specify hostkeys (repeatable)\n"
+					"-r keyfile      Specify hostkeys (repeatable)\n"
 					"		defaults: \n"
 #if DROPBEAR_DSS
-					"		dss %s\n"
+					"		- dss %s\n"
 #endif
 #if DROPBEAR_RSA
-					"		rsa %s\n"
+					"		- rsa %s\n"
 #endif
 #if DROPBEAR_ECDSA
-					"		ecdsa %s\n"
+					"		- ecdsa %s\n"
 #endif
 #if DROPBEAR_DELAY_HOSTKEY
 					"-R		Create hostkeys as required\n" 
@@ -99,11 +99,11 @@ static void printhelp(const char * progname) {
 					"-W <receive_window_buffer> (default %d, larger may be faster, max 1MB)\n"
 					"-K <keepalive>  (0 is never, default %d, in seconds)\n"
 					"-I <idle_timeout>  (0 is never, default %d, in seconds)\n"
-					"-V    Version\n"
-#if DROPBEAR_ENABLE_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
                                         "-A <authplugin>[,<options>]\n"
                                         "               Enable external public key auth through <authplugin>\n"
 #endif
+					"-V    Version\n"
 #if DEBUG_TRACE
 					"-v		verbose (compiled with DEBUG_TRACE)\n"
 #endif
@@ -133,7 +133,7 @@ void svr_getopts(int argc, char ** argv) {
 	char* maxauthtries_arg = NULL;
 	char* keyfile = NULL;
 	char c;
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         char* pubkey_plugin = NULL;
 #endif
 
@@ -163,7 +163,7 @@ void svr_getopts(int argc, char ** argv) {
 #if DROPBEAR_SVR_REMOTETCPFWD
 	svr_opts.noremotetcp = 0;
 #endif
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         svr_opts.pubkey_plugin = NULL;
         svr_opts.pubkey_plugin_options = NULL;
 #endif
@@ -285,7 +285,7 @@ void svr_getopts(int argc, char ** argv) {
 				case 'u':
 					/* backwards compatibility with old urandom option */
 					break;
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
                                 case 'A':
                                         next = &pubkey_plugin;
                                         break;
@@ -410,7 +410,7 @@ void svr_getopts(int argc, char ** argv) {
 	if (svr_opts.forced_command) {
 		dropbear_log(LOG_INFO, "Forced command set to '%s'", svr_opts.forced_command);
 	}
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         if (pubkey_plugin) {
             char *args = strchr(pubkey_plugin, ',');
             if (args) *args='\0';

--- a/svr-session.c
+++ b/svr-session.c
@@ -129,7 +129,7 @@ void svr_session(int sock, int childpipe) {
             /* RTLD_NOW: fails if not all the symbols are resolved now. Better fail now than at run-time */
             svr_ses.epka_plugin_handle = dlopen(svr_opts.pubkey_plugin, RTLD_NOW);
             if (svr_ses.epka_plugin_handle == NULL) {
-                dropbear_exit("failed to load external pubkey plugin");
+                dropbear_exit("failed to load external pubkey plugin '%s': %s", svr_opts.pubkey_plugin, dlerror());
             }
             pluginConstructor = (PubkeyExtPlugin_newFn)dlsym(svr_ses.epka_plugin_handle, DROPBEAR_PUBKEY_PLUGIN_FNNAME_NEW);
             if (!pluginConstructor) {

--- a/svr-session.c
+++ b/svr-session.c
@@ -90,20 +90,14 @@ svr_session_cleanup(void) {
 	svr_ses.childpidsize = 0;
 
 #if DROPBEAR_EPKA
-        if (svr_ses.pubkey_plugin_handle != NULL) {
-            if (svr_ses.pubkey_plugin_handle_instance) {
-                svr_ses.pubkey_plugin_delete(svr_ses.pubkey_plugin_handle_instance);
-                svr_ses.pubkey_plugin_handle_instance = NULL;
+        if (svr_ses.epka_plugin_handle != NULL) {
+            if (svr_ses.epka_instance) {
+                svr_ses.epka_instance->delete_plugin(svr_ses.epka_instance);
+                svr_ses.epka_instance = NULL;
             }
 
-            svr_ses.pubkey_plugin_new = NULL;
-            svr_ses.pubkey_plugin_checkPubKey = NULL;
-            svr_ses.pubkey_plugin_authSuccess = NULL;
-            svr_ses.pubkey_plugin_sessionDelete = NULL;
-            svr_ses.pubkey_plugin_delete = NULL;
-
-            dlclose(svr_ses.pubkey_plugin_handle);
-            svr_ses.pubkey_plugin_handle = NULL;
+            dlclose(svr_ses.epka_plugin_handle);
+            svr_ses.epka_plugin_handle = NULL;
         }
 #endif
 }
@@ -121,46 +115,45 @@ void svr_session(int sock, int childpipe) {
 #endif
 
 #if DROPBEAR_EPKA
-        svr_ses.pubkey_plugin_handle = NULL;
-        svr_ses.pubkey_plugin_handle_instance = NULL;
+        /* Initializes the EPKA Plugin */
+        svr_ses.epka_plugin_handle = NULL;
+        svr_ses.epka_instance = NULL;
         if (svr_opts.pubkey_plugin) {
 #if DEBUG_TRACE
             const int verbose = debug_trace;
 #else
             const int verbose = 0;
 #endif
+            PubkeyExtPlugin_newFn  pluginConstructor;
 
             /* RTLD_NOW: fails if not all the symbols are resolved now. Better fail now than at run-time */
-            svr_ses.pubkey_plugin_handle = dlopen(svr_opts.pubkey_plugin, RTLD_NOW);
-            if (svr_ses.pubkey_plugin_handle == NULL) {
+            svr_ses.epka_plugin_handle = dlopen(svr_opts.pubkey_plugin, RTLD_NOW);
+            if (svr_ses.epka_plugin_handle == NULL) {
                 dropbear_exit("failed to load external pubkey plugin");
             }
-            /* Initializes ALL the function pointers of the API */
-            svr_ses.pubkey_plugin_new = (PubkeyExtPlugin_newFn)dlsym(svr_ses.pubkey_plugin_handle, DROPBEAR_PUBKEY_PLUGIN_FNNAME_NEW);
-            if (!svr_ses.pubkey_plugin_new) {
-                dropbear_exit("init method not found in external pubkey plugin");
-            }
-            svr_ses.pubkey_plugin_checkPubKey = (PubkeyExtPlugin_checkPubKeyFn)dlsym(svr_ses.pubkey_plugin_handle, DROPBEAR_PUBKEY_PLUGIN_FNNAME_CHECKPUBKEY);
-            if (!svr_ses.pubkey_plugin_checkPubKey) {
-                dropbear_exit("checkPubKey method not found in external pubkey plugin");
-            }
-            svr_ses.pubkey_plugin_authSuccess = (PubkeyExtPlugin_authSuccessFn)dlsym(svr_ses.pubkey_plugin_handle, DROPBEAR_PUBKEY_PLUGIN_FNNAME_AUTHSUCCESS);
-            if (!svr_ses.pubkey_plugin_authSuccess) {
-                dropbear_exit("authSuccess method not found in external pubkey plugin");
-            }
-            svr_ses.pubkey_plugin_sessionDelete = (PubkeyExtPlugin_sessionDeleteFn)dlsym(svr_ses.pubkey_plugin_handle, DROPBEAR_PUBKEY_PLUGIN_FNNAME_SESSIONDELETE);
-            if (!svr_ses.pubkey_plugin_sessionDelete) {
-                dropbear_exit("sessionDelete method not found in external pubkey plugin");
-            }
-            svr_ses.pubkey_plugin_delete = (PubkeyExtPlugin_deleteFn)dlsym(svr_ses.pubkey_plugin_handle, DROPBEAR_PUBKEY_PLUGIN_FNNAME_DELETE);
-            if (!svr_ses.pubkey_plugin_delete) {
-                dropbear_exit("delete method not found in external pubkey plugin");
+            pluginConstructor = (PubkeyExtPlugin_newFn)dlsym(svr_ses.epka_plugin_handle, DROPBEAR_PUBKEY_PLUGIN_FNNAME_NEW);
+            if (!pluginConstructor) {
+                dropbear_exit("plugin constructor method not found in external pubkey plugin");
             }
 
             /* Create an instance of the plugin */
-            svr_ses.pubkey_plugin_handle_instance = svr_ses.pubkey_plugin_new(verbose, svr_opts.pubkey_plugin_options);
-            if (svr_ses.pubkey_plugin_handle_instance == NULL) {
+            svr_ses.epka_instance = pluginConstructor(verbose, svr_opts.pubkey_plugin_options);
+            if (svr_ses.epka_instance == NULL) {
                 dropbear_exit("external plugin initialization failed");
+            }
+            /* Check if the plugin is compatible */
+            if ( (svr_ses.epka_instance->api_version[0] != DROPBEAR_EPKA_VERSION_MAJOR) ||
+                 (svr_ses.epka_instance->api_version[1] < DROPBEAR_EPKA_VERSION_MINOR) ) {
+                dropbear_exit("plugin version check failed: "
+                              "Dropbear=%d.%d, plugin=%d.%d",
+                        DROPBEAR_EPKA_VERSION_MAJOR, DROPBEAR_EPKA_VERSION_MINOR,
+                        svr_ses.epka_instance->api_version[0], svr_ses.epka_instance->api_version[1]);
+            }
+            if (svr_ses.epka_instance->api_version[1] > DROPBEAR_EPKA_VERSION_MINOR) {
+                dropbear_log(LOG_WARNING, "plugin API newer than dropbear API: "
+                              "Dropbear=%d.%d, plugin=%d.%d",
+                        DROPBEAR_EPKA_VERSION_MAJOR, DROPBEAR_EPKA_VERSION_MINOR,
+                        svr_ses.epka_instance->api_version[0], svr_ses.epka_instance->api_version[1]);
             }
             dropbear_log(LOG_INFO, "successfully loaded and initialized pubkey plugin '%s'", svr_opts.pubkey_plugin);
         }
@@ -217,10 +210,10 @@ void svr_dropbear_exit(int exitcode, const char* format, va_list param) {
 	int i;
 
 #if DROPBEAR_EPKA
-        if ((svr_ses.pubkey_plugin_handle != NULL) && (ses.pubkey_plugin_session != NULL)) {
-            svr_ses.pubkey_plugin_sessionDelete(svr_ses.pubkey_plugin_handle, ses.pubkey_plugin_session);
+        if ((ses.epka_session != NULL)) {
+            svr_ses.epka_instance->delete_session(ses.epka_session);
         }
-        ses.pubkey_plugin_session = NULL;
+        ses.epka_session = NULL;
 #endif
 
 	/* Render the formatted exit message */

--- a/svr-session.c
+++ b/svr-session.c
@@ -89,7 +89,7 @@ svr_session_cleanup(void) {
 	m_free(svr_ses.childpids);
 	svr_ses.childpidsize = 0;
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         if (svr_ses.pubkey_plugin_handle != NULL) {
             if (svr_ses.pubkey_plugin_handle_instance) {
                 svr_ses.pubkey_plugin_delete(svr_ses.pubkey_plugin_handle_instance);
@@ -120,7 +120,7 @@ void svr_session(int sock, int childpipe) {
 	svr_ses.server_pid = getpid();
 #endif
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         svr_ses.pubkey_plugin_handle = NULL;
         svr_ses.pubkey_plugin_handle_instance = NULL;
         if (svr_opts.pubkey_plugin) {
@@ -216,7 +216,7 @@ void svr_dropbear_exit(int exitcode, const char* format, va_list param) {
 	char fullmsg[300];
 	int i;
 
-#if DROPBEAR_SVR_PUBKEY_EXTPLUGIN
+#if DROPBEAR_EPKA
         if ((svr_ses.pubkey_plugin_handle != NULL) && (ses.pubkey_plugin_session != NULL)) {
             svr_ses.pubkey_plugin_sessionDelete(svr_ses.pubkey_plugin_handle, ses.pubkey_plugin_session);
         }

--- a/svr-session.c
+++ b/svr-session.c
@@ -114,6 +114,14 @@ void svr_session(int sock, int childpipe) {
 	svr_ses.server_pid = getpid();
 #endif
 
+	/* for logging the remote address */
+	get_socket_address(ses.sock_in, NULL, NULL, &host, &port, 0);
+	len = strlen(host) + strlen(port) + 2;
+	svr_ses.addrstring = m_malloc(len);
+	snprintf(svr_ses.addrstring, len, "%s:%s", host, port);
+	m_free(host);
+	m_free(port);
+
 #if DROPBEAR_EPKA
         /* Initializes the EPKA Plugin */
         svr_ses.epka_plugin_handle = NULL;
@@ -137,7 +145,7 @@ void svr_session(int sock, int childpipe) {
             }
 
             /* Create an instance of the plugin */
-            svr_ses.epka_instance = pluginConstructor(verbose, svr_opts.pubkey_plugin_options);
+            svr_ses.epka_instance = pluginConstructor(verbose, svr_opts.pubkey_plugin_options, svr_ses.addrstring);
             if (svr_ses.epka_instance == NULL) {
                 dropbear_exit("external plugin initialization failed");
             }
@@ -163,14 +171,6 @@ void svr_session(int sock, int childpipe) {
 	chaninitialise(svr_chantypes);
 	svr_chansessinitialise();
 	svr_algos_initialise();
-
-	/* for logging the remote address */
-	get_socket_address(ses.sock_in, NULL, NULL, &host, &port, 0);
-	len = strlen(host) + strlen(port) + 2;
-	svr_ses.addrstring = m_malloc(len);
-	snprintf(svr_ses.addrstring, len, "%s:%s", host, port);
-	m_free(host);
-	m_free(port);
 
 	get_socket_address(ses.sock_in, NULL, NULL, 
 			&svr_ses.remotehost, NULL, 1);

--- a/sysoptions.h
+++ b/sysoptions.h
@@ -241,8 +241,8 @@ If you test it please contact the Dropbear author */
 	#error "At least one server authentication type must be enabled. DROPBEAR_SVR_PUBKEY_AUTH and DROPBEAR_SVR_PASSWORD_AUTH are recommended."
 #endif
 
-#if (DROPBEAR_SVR_PUBKEY_EXTPLUGIN && !DROPBEAR_SVR_PUBKEY_AUTH)
-	#error "You must define DROPBEAR_SVR_PUBKEY_AUTH in order to use DROPBEAR_SVR_PUBKEY_EXTPLUGIN"
+#if (DROPBEAR_EPKA && !DROPBEAR_SVR_PUBKEY_AUTH)
+	#error "You must define DROPBEAR_SVR_PUBKEY_AUTH in order to use External Public Key Authentication (EPKA)"
 #endif
 
 #if !(DROPBEAR_AES128 || DROPBEAR_3DES || DROPBEAR_AES256 || DROPBEAR_BLOWFISH \

--- a/sysoptions.h
+++ b/sysoptions.h
@@ -241,6 +241,9 @@ If you test it please contact the Dropbear author */
 	#error "At least one server authentication type must be enabled. DROPBEAR_SVR_PUBKEY_AUTH and DROPBEAR_SVR_PASSWORD_AUTH are recommended."
 #endif
 
+#if (DROPBEAR_SVR_PUBKEY_EXTPLUGIN && !DROPBEAR_SVR_PUBKEY_AUTH)
+	#error "You must define DROPBEAR_SVR_PUBKEY_AUTH in order to use DROPBEAR_SVR_PUBKEY_EXTPLUGIN"
+#endif
 
 #if !(DROPBEAR_AES128 || DROPBEAR_3DES || DROPBEAR_AES256 || DROPBEAR_BLOWFISH \
       || DROPBEAR_TWOFISH256 || DROPBEAR_TWOFISH128)


### PR DESCRIPTION
As discussed over email, I have created an API for dropbear to delegate to an external plugin the public-key authentication.

Description and documentation of the public key API is in: 
([https://github.com/fabriziobertocci/dropbear-epka](https://github.com/fabriziobertocci/dropbear-epka))

Unless enabled during config (--enable-epka), all the changes propsed are ifdef'd out.

Once enabled, it introduces a new command-line argument (-A) to dropbear (server) to dynamically load an external shared library to delegate public-key authentication. 3 examples of plug-in libraries are provided in the ([https://github.com/fabriziobertocci/dropbear-epka](dropbear-epka)) repository.

