### PR TITLE
Support servers without multiple user support

### DIFF
--- a/default_options.h
+++ b/default_options.h
@@ -196,6 +196,9 @@ group1 in Dropbear server too */
  * authorized_keys file into account */
 #define DROPBEAR_SVR_PUBKEY_OPTIONS 1
 
+/* Disable if your kernel does not have multiple user support */
+#define DROPBEAR_SVR_MULTIUSER 1
+
 /* Client authentication options */
 #define DROPBEAR_CLI_PASSWORD_AUTH 1
 #define DROPBEAR_CLI_PUBKEY_AUTH 1

--- a/svr-agentfwd.c
+++ b/svr-agentfwd.c
@@ -151,6 +151,7 @@ void svr_agentcleanup(struct ChanSess * chansess) {
 
 	if (chansess->agentfile != NULL && chansess->agentdir != NULL) {
 
+#if DROPBEAR_SVR_MULTIUSER
 		/* Remove the dir as the user. That way they can't cause problems except
 		 * for themselves */
 		uid = getuid();
@@ -159,6 +160,7 @@ void svr_agentcleanup(struct ChanSess * chansess) {
 			(seteuid(ses.authstate.pw_uid)) < 0) {
 			dropbear_exit("Failed to set euid");
 		}
+#endif
 
 		/* 2 for "/" and "\0" */
 		len = strlen(chansess->agentdir) + strlen(chansess->agentfile) + 2;
@@ -170,10 +172,12 @@ void svr_agentcleanup(struct ChanSess * chansess) {
 
 		rmdir(chansess->agentdir);
 
+#if DROPBEAR_SVR_MULTIUSER
 		if ((seteuid(uid)) < 0 ||
 			(setegid(gid)) < 0) {
 			dropbear_exit("Failed to revert euid");
 		}
+#endif
 
 		m_free(chansess->agentfile);
 		m_free(chansess->agentdir);
@@ -216,6 +220,7 @@ static int bindagent(int fd, struct ChanSess * chansess) {
 	gid_t gid;
 	int ret = DROPBEAR_FAILURE;
 
+#if DROPBEAR_SVR_MULTIUSER
 	/* drop to user privs to make the dir/file */
 	uid = getuid();
 	gid = getgid();
@@ -223,6 +228,7 @@ static int bindagent(int fd, struct ChanSess * chansess) {
 		(seteuid(ses.authstate.pw_uid)) < 0) {
 		dropbear_exit("Failed to set euid");
 	}
+#endif
 
 	memset((void*)&addr, 0x0, sizeof(addr));
 	addr.sun_family = AF_UNIX;
@@ -262,10 +268,12 @@ bindsocket:
 
 
 out:
+#if DROPBEAR_SVR_MULTIUSER
 	if ((seteuid(uid)) < 0 ||
 		(setegid(gid)) < 0) {
 		dropbear_exit("Failed to revert euid");
 	}
+#endif
 	return ret;
 }
 

--- a/svr-auth.c
+++ b/svr-auth.c
@@ -276,7 +276,7 @@ static int checkusername(const char *username, unsigned int userlen) {
 
 	/* check if we are running as non-root, and login user is different from the server */
 	uid = geteuid();
-	if (uid != 0 && uid != ses.authstate.pw_uid) {
+	if (!(DROPBEAR_SVR_MULTIUSER && uid == 0) && uid != ses.authstate.pw_uid) {
 		TRACE(("running as nonroot, only server uid is allowed"))
 		dropbear_log(LOG_WARNING,
 				"Login attempt with wrong user %s from %s",

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -347,6 +347,7 @@ static int checkpubkey(const char* algo, unsigned int algolen,
 	snprintf(filename, len + 22, "%s/.ssh/authorized_keys", 
 				ses.authstate.pw_dir);
 
+#if DROPBEAR_SVR_MULTIUSER
 	/* open the file as the authenticating user. */
 	origuid = getuid();
 	origgid = getgid();
@@ -354,13 +355,16 @@ static int checkpubkey(const char* algo, unsigned int algolen,
 		(seteuid(ses.authstate.pw_uid)) < 0) {
 		dropbear_exit("Failed to set euid");
 	}
+#endif
 
 	authfile = fopen(filename, "r");
 
+#if DROPBEAR_SVR_MULTIUSER
 	if ((seteuid(origuid)) < 0 ||
 		(setegid(origgid)) < 0) {
 		dropbear_exit("Failed to revert euid");
 	}
+#endif
 
 	if (authfile == NULL) {
 		goto out;

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -949,6 +949,7 @@ static void execchild(const void *user_data) {
 #endif /* HAVE_CLEARENV */
 #endif /* DEBUG_VALGRIND */
 
+#if DROPBEAR_SVR_MULTIUSER
 	/* We can only change uid/gid as root ... */
 	if (getuid() == 0) {
 
@@ -972,6 +973,7 @@ static void execchild(const void *user_data) {
 			dropbear_exit("Couldn't	change user as non-root");
 		}
 	}
+#endif
 
 	/* set env vars */
 	addnewvar("USER", ses.authstate.pw_name);


### PR DESCRIPTION
Some kernels for embedded devices do not have multiple user support, so setuid() etc will fail. This allows you to login on such a device. It will fail if you attempt to login as a non-root user.