### PR TITLE
Fix for issue successful login of disabled user

### DIFF
--- a/svr-authpam.c
+++ b/svr-authpam.c
@@ -275,6 +275,7 @@ void svr_auth_pam(int valid_user) {
 		/* PAM auth succeeded but the username isn't allowed in for another reason
 		(checkusername() failed) */
 		send_msg_userauth_failure(0, 1);
+		goto cleanup;
 	}
 
 	/* successful authentication */


### PR DESCRIPTION
This commit introduces fix for scenario:
1. Root login disabled on dropbear
2. PAM authentication model enabled

While login as root user, after prompt for password
user is being notified about login failure, but
after second attempt of prompt for password within
same session, login becomes successful.

Signed-off-by: Pawel Rapkiewicz <pawel.rapkiewicz@gmail.com>