### PR TITLE
RFC: Improve address logging on early exit messages

### DIFF
--- a/svr-auth.c
+++ b/svr-auth.c
@@ -241,8 +241,7 @@ static int checkusername(const char *username, unsigned int userlen) {
 	}
 
 	if (strlen(username) != userlen) {
-		dropbear_exit("Attempted username with a null byte from %s",
-			svr_ses.addrstring);
+		dropbear_exit("Attempted username with a null byte");
 	}
 
 	if (ses.authstate.username == NULL) {
@@ -252,8 +251,7 @@ static int checkusername(const char *username, unsigned int userlen) {
 	} else {
 		/* check username hasn't changed */
 		if (strcmp(username, ses.authstate.username) != 0) {
-			dropbear_exit("Client trying multiple usernames from %s",
-				svr_ses.addrstring);
+			dropbear_exit("Client trying multiple usernames");
 		}
 	}
 
@@ -268,8 +266,7 @@ static int checkusername(const char *username, unsigned int userlen) {
 	if (!ses.authstate.pw_name) {
 		TRACE(("leave checkusername: user '%s' doesn't exist", username))
 		dropbear_log(LOG_WARNING,
-				"Login attempt for nonexistent user from %s",
-				svr_ses.addrstring);
+				"Login attempt for nonexistent user");
 		ses.authstate.checkusername_failed = 1;
 		return DROPBEAR_FAILURE;
 	}
@@ -279,9 +276,8 @@ static int checkusername(const char *username, unsigned int userlen) {
 	if (!(DROPBEAR_SVR_MULTIUSER && uid == 0) && uid != ses.authstate.pw_uid) {
 		TRACE(("running as nonroot, only server uid is allowed"))
 		dropbear_log(LOG_WARNING,
-				"Login attempt with wrong user %s from %s",
-				ses.authstate.pw_name,
-				svr_ses.addrstring);
+				"Login attempt with wrong user %s",
+				ses.authstate.pw_name);
 		ses.authstate.checkusername_failed = 1;
 		return DROPBEAR_FAILURE;
 	}
@@ -440,8 +436,8 @@ void send_msg_userauth_failure(int partial, int incrfail) {
 		} else {
 			userstr = ses.authstate.pw_name;
 		}
-		dropbear_exit("Max auth tries reached - user '%s' from %s",
-				userstr, svr_ses.addrstring);
+		dropbear_exit("Max auth tries reached - user '%s'",
+				userstr);
 	}
 	
 	TRACE(("leave send_msg_userauth_failure"))

--- a/svr-session.c
+++ b/svr-session.c
@@ -222,7 +222,7 @@ void svr_dropbear_exit(int exitcode, const char* format, va_list param) {
 	/* Add the prefix depending on session/auth state */
 	if (!ses.init_done) {
 		/* before session init */
-		snprintf(fullmsg, sizeof(fullmsg), "Early exit: %s", exitmsg);
+		snprintf(fullmsg, sizeof(fullmsg), "Early exit from <%s> %s", svr_ses.addrstring, exitmsg);
 	} else if (ses.authstate.authdone) {
 		/* user has authenticated */
 		snprintf(fullmsg, sizeof(fullmsg),
@@ -231,11 +231,11 @@ void svr_dropbear_exit(int exitcode, const char* format, va_list param) {
 	} else if (ses.authstate.pw_name) {
 		/* we have a potential user */
 		snprintf(fullmsg, sizeof(fullmsg), 
-				"Exit before auth (user '%s', %u fails): %s",
-				ses.authstate.pw_name, ses.authstate.failcount, exitmsg);
+				"Exit before auth from <%s> (user '%s', %u fails): %s",
+				svr_ses.addrstring, ses.authstate.pw_name, ses.authstate.failcount, exitmsg);
 	} else {
 		/* before userauth */
-		snprintf(fullmsg, sizeof(fullmsg), "Exit before auth: %s", exitmsg);
+		snprintf(fullmsg, sizeof(fullmsg), "Exit before auth from <%s> %s", svr_ses.addrstring, exitmsg);
 	}
 
 	dropbear_log(LOG_INFO, "%s", fullmsg);


### PR DESCRIPTION
Change 'Early exit' and 'Exit before auth' messages to include the IP
address & port as part of the message.

This allows log scanning utilities such as 'fail2ban' to obtain the
offending IP address as part of the failure event instead of extracting
the PID from the message and then scanning the log again for match
'child connection from' messages

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>

Delimiting with < > may be a step too far... or the whole idea... hence the RFC :-)