### PR TITLE
Fix build error missing original_command member

### DIFF
--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -696,7 +696,11 @@ static int sessioncommand(struct Channel *channel, struct ChanSess *chansess,
 
 	/* take global command into account */
 	if (svr_opts.forced_command) {
+#if DROPBEAR_SVR_PUBKEY_OPTIONS_BUILT
 		chansess->original_command = chansess->cmd ? : m_strdup("");
+#else
+		m_free(chansess->cmd);
+#endif
 		chansess->cmd = m_strdup(svr_opts.forced_command);
 	} else {
 		/* take public key option 'command' into account */


### PR DESCRIPTION
When option DROPBEAR_SVR_PUBKEY_AUTH or DROPBEAR_SVR_PUBKEY_OPTIONS is
turned off, building off, building runs into an error saying
`no member named 'original_command' in 'struct ChanSess'`.

The reason is either of the options is turned off, option
DROPBEAR_SVR_PUBKEY_OPTIONS_BUILT is turned off, and original_command
field is not compiled. But sessioncommand() still use this field without
macro guardings.

The related code is used to backup original command to original_command.
This fix guards related code, and prevent memory leak by freeup original
command.