### PR TITLE
MOTD enabled by default as the manpage says

### DIFF
--- a/default_options.h
+++ b/default_options.h
@@ -174,7 +174,7 @@ group1 in Dropbear server too */
 #define DO_HOST_LOOKUP 0
 
 /* Whether to print the message of the day (MOTD). */
-#define DO_MOTD 0
+#define DO_MOTD 1
 #define MOTD_FILENAME "/etc/motd"
 
 /* Authentication Types - at least one required.


### PR DESCRIPTION
The man page (https://github.com/mkj/dropbear/blob/master/dropbear.8) says MOTD will be printed by default for any login shell, but it was disabled at compile time. Probably happened by accident when this code was moved from `options.h` to `default_options.h`.