### PR TITLE
Fallback for key generation on systems or filesystems without hard link support

### DIFF
--- a/gensignkey.c
+++ b/gensignkey.c
@@ -8,14 +8,21 @@
 #include "dbrandom.h"
 
 /* Returns DROPBEAR_SUCCESS or DROPBEAR_FAILURE */
-static int buf_writefile(buffer * buf, const char * filename) {
+static int buf_writefile(buffer * buf, const char * filename, int skip_exist) {
 	int ret = DROPBEAR_FAILURE;
 	int fd = -1;
 
 	fd = open(filename, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
-		dropbear_log(LOG_ERR, "Couldn't create new file %s: %s",
-			filename, strerror(errno));
+		/* If generating keys on connection (skip_exist) it's OK to get EEXIST
+		- we probably just lost a race with another connection to generate the key */
+		if (skip_exist && errno == EEXIST) {
+			ret = DROPBEAR_SUCCESS;
+		} else {
+			dropbear_log(LOG_ERR, "Couldn't create new file %s: %s",
+				filename, strerror(errno));
+		}
+
 		goto out;
 	}
 
@@ -134,7 +141,7 @@ int signkey_generate(enum signkey_type keytype, int bits, const char* filename, 
 
 	fn_temp = m_malloc(strlen(filename) + 30);
 	snprintf(fn_temp, strlen(filename)+30, "%s.tmp%d", filename, getpid());
-	ret = buf_writefile(buf, fn_temp);
+	ret = buf_writefile(buf, fn_temp, 0);
 
 	if (ret == DROPBEAR_FAILURE) {
 		goto out;
@@ -144,10 +151,16 @@ int signkey_generate(enum signkey_type keytype, int bits, const char* filename, 
 		/* If generating keys on connection (skipexist) it's OK to get EEXIST 
 		- we probably just lost a race with another connection to generate the key */
 		if (!(skip_exist && errno == EEXIST)) {
-			dropbear_log(LOG_ERR, "Failed moving key file to %s: %s", filename,
-				strerror(errno));
-			/* XXX fallback to non-atomic copy for some filesystems? */
-			ret = DROPBEAR_FAILURE;
+			if (errno == EPERM || errno == EACCES) {
+				/* Non-atomic fallback when hard-links not allowed or unsupported */
+				buf_setpos(buf, 0);
+				ret = buf_writefile(buf, filename, skip_exist);
+			} else {
+				dropbear_log(LOG_ERR, "Failed moving key file to %s: %s", filename,
+					strerror(errno));
+				ret = DROPBEAR_FAILURE;
+			}
+
 			goto out;
 		}
 	}


### PR DESCRIPTION
This PR adds a non-atomic fallback for key generation in instances where using `link()` is not possible.

I hit this issue under Android as most stock Android ROMs block the creation of hard links via SELinux policy but this also covers the case of key generation on filesystems without hard link support.