### PR TITLE
Added default LD_LIBRARY_PATH to environment

### DIFF
--- a/default_options.h
+++ b/default_options.h
@@ -297,4 +297,7 @@ be overridden at runtime with -I. 0 disables idle timeouts */
 /* The default path. This will often get replaced by the shell */
 #define DEFAULT_PATH "/usr/bin:/bin"
 
+/* The default ld library path. This will often get replaced by the shell */
+#define DEFAULT_LD_LIBRARY_PATH "/usr/lib:/lib"
+
 #endif /* DROPBEAR_DEFAULT_OPTIONS_H_ */

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -981,6 +981,7 @@ static void execchild(const void *user_data) {
 	addnewvar("HOME", ses.authstate.pw_dir);
 	addnewvar("SHELL", get_user_shell());
 	addnewvar("PATH", DEFAULT_PATH);
+        addnewvar("LD_LIBRARY_PATH", DEFAULT_LD_LIBRARY_PATH);
 	if (chansess->term != NULL) {
 		addnewvar("TERM", chansess->term);
 	}


### PR DESCRIPTION
This is needed to make scp work on some embedded systems