### PR TITLE
CBC mode cleanup

### DIFF
--- a/common-algo.c
+++ b/common-algo.c
@@ -169,12 +169,18 @@ algo_type sshciphers[] = {
 #if DROPBEAR_TWOFISH128
 	{"twofish128-cbc", 0, &dropbear_twofish128, 1, &dropbear_mode_cbc},
 #endif
+#endif /* DROPBEAR_ENABLE_CBC_MODE */
+
 #if DROPBEAR_3DES
+#if DROPBEAR_ENABLE_CTR_MODE
 	{"3des-ctr", 0, &dropbear_3des, 1, &dropbear_mode_ctr},
 #endif
-#if DROPBEAR_3DES
+#if DROPBEAR_ENABLE_CBC_MODE
 	{"3des-cbc", 0, &dropbear_3des, 1, &dropbear_mode_cbc},
 #endif
+#endif /* DROPBEAR_3DES */
+
+#if DROPBEAR_ENABLE_CBC_MODE
 #if DROPBEAR_BLOWFISH
 	{"blowfish-cbc", 0, &dropbear_blowfish, 1, &dropbear_mode_cbc},
 #endif

--- a/libtomcrypt/src/headers/tomcrypt_dropbear.h
+++ b/libtomcrypt/src/headers/tomcrypt_dropbear.h
@@ -27,7 +27,7 @@
 #define LTC_DES
 #endif
 
-#if DROPBEAR_ENABLE_CTR_MODE
+#if DROPBEAR_ENABLE_CBC_MODE
 #define LTC_CBC_MODE
 #endif
 

--- a/session.h
+++ b/session.h
@@ -77,7 +77,9 @@ struct key_context_directional {
 #endif
 	/* actual keys */
 	union {
+#if DROPBEAR_ENABLE_CBC_MODE
 		symmetric_CBC cbc;
+#endif
 #if DROPBEAR_ENABLE_CTR_MODE
 		symmetric_CTR ctr;
 #endif


### PR DESCRIPTION
LibTomCrypt CBC support depends on CTR, symmetric_CBC is being unconditionally referenced even when DROPBEAR_ENABLE_CBC_MODE is disabled, it causes unnecessary compiled code and build errors when DROPBEAR_ENABLE_CRT_MODE is disabled.
Commit 4122cac66b139492d5b7fa6a1b8afcb1bfc529f7 has moved 3des-ctr into CBC group, it also causes build error with CBC the only mode w/o CTR enabled.
With both CBC & CTR modes disabled, cipher_state union may become empty which is not allowed by ISO C, it's better to have explicit check as it's already done for ciphers. So far no CTR/CBC is quite impossible scenario, but with new AEAD modes (Chacha20-Poly1305 and AES-GCM PR #93) both CBC and CTR may be safely disabled.