### PR TITLE
Allow DH to be completely disabled

### DIFF
--- a/cli-kex.c
+++ b/cli-kex.c
@@ -155,10 +155,12 @@ void recv_msg_kexdh_reply() {
 #endif
 	}
 
+#if DROPBEAR_NORMAL_DH
 	if (cli_ses.dh_param) {
 		free_kexdh_param(cli_ses.dh_param);
 		cli_ses.dh_param = NULL;
 	}
+#endif
 #if DROPBEAR_ECDH
 	if (cli_ses.ecdh_param) {
 		free_kexecdh_param(cli_ses.ecdh_param);

--- a/common-kex.c
+++ b/common-kex.c
@@ -546,6 +546,7 @@ void recv_msg_kexinit() {
 	TRACE(("leave recv_msg_kexinit"))
 }
 
+#if DROPBEAR_NORMAL_DH
 static void load_dh_p(mp_int * dh_p)
 {
 	bytes_to_mp(dh_p, ses.newkeys->algo_kex->dh_p_bytes, 
@@ -654,6 +655,7 @@ void kexdh_comb_key(struct kex_dh_param *param, mp_int *dh_pub_them,
 	/* calculate the hash H to sign */
 	finish_kexhashbuf();
 }
+#endif
 
 #if DROPBEAR_ECDH
 struct kex_ecdh_param *gen_kexecdh_param() {

--- a/dh_groups.c
+++ b/dh_groups.c
@@ -1,6 +1,8 @@
 #include "options.h"
 #include "dh_groups.h"
 
+#if DROPBEAR_DH_NORMAL
+
 #if DROPBEAR_DH_GROUP1
 /* diffie-hellman-group1-sha1 value for p */
 const unsigned char dh_p_1[DH_P_1_LEN] = {
@@ -92,3 +94,4 @@ const unsigned char dh_p_16[DH_P_16_LEN] = {
 /* Same for all groups */
 const int DH_G_VAL = 2;
 
+#endif

--- a/dh_groups.h
+++ b/dh_groups.h
@@ -2,6 +2,8 @@
 #define DROPBEAR_DH_GROUPS_H
 #include "options.h"
 
+#if DROPBEAR_DH_NORMAL
+
 #if DROPBEAR_DH_GROUP1
 #define DH_P_1_LEN 128
 extern const unsigned char dh_p_1[DH_P_1_LEN];
@@ -17,8 +19,8 @@ extern const unsigned char dh_p_14[DH_P_14_LEN];
 extern const unsigned char dh_p_16[DH_P_16_LEN];
 #endif
 
-
 extern const int DH_G_VAL;
 
+#endif
 
 #endif

--- a/kex.h
+++ b/kex.h
@@ -36,10 +36,12 @@ void recv_msg_newkeys(void);
 void kexfirstinitialise(void);
 void finish_kexhashbuf(void);
 
+#if DROPBEAR_NORMAL_DH
 struct kex_dh_param *gen_kexdh_param(void);
 void free_kexdh_param(struct kex_dh_param *param);
 void kexdh_comb_key(struct kex_dh_param *param, mp_int *dh_pub_them,
 		sign_key *hostkey);
+#endif
 
 #if DROPBEAR_ECDH
 struct kex_ecdh_param *gen_kexecdh_param(void);
@@ -87,10 +89,12 @@ struct KEXState {
 
 };
 
+#if DROPBEAR_NORMAL_DH
 struct kex_dh_param {
 	mp_int pub; /* e */
 	mp_int priv; /* x */
 };
+#endif
 
 #if DROPBEAR_ECDH
 struct kex_ecdh_param {
@@ -104,9 +108,6 @@ struct kex_curve25519_param {
 	unsigned char priv[CURVE25519_LEN];
 	unsigned char pub[CURVE25519_LEN];
 };
-
-/* No header file for curve25519_donna */
-int curve25519_donna(unsigned char *out, const unsigned char *secret, const unsigned char *other);
 #endif
 
 #endif /* DROPBEAR_KEX_H_ */


### PR DESCRIPTION
Reduces binary size by ~2kB by default and by 21kB with no other libtommath functions users, ex. with curve25519 kex and ed25519 key only.