### PR TITLE
Fix ChaCha20 on 32-bit platforms

### DIFF
--- a/chachapoly.c
+++ b/chachapoly.c
@@ -82,7 +82,7 @@ static int dropbear_chachapoly_crypt(unsigned int seq,
 		return CRYPT_ERROR;
 	}
 
-	STORE64H(seq, seqbuf);
+	STORE64H((uint64_t)seq, seqbuf);
 	chacha_ivctr64(&state->chacha, seqbuf, sizeof(seqbuf), 0);
 	if ((err = chacha_keystream(&state->chacha, key, sizeof(key))) != CRYPT_OK) {
 		return err;
@@ -128,7 +128,7 @@ static int dropbear_chachapoly_getlength(unsigned int seq,
 		return CRYPT_ERROR;
 	}
 
-	STORE64H(seq, seqbuf);
+	STORE64H((uint64_t)seq, seqbuf);
 	chacha_ivctr64(&state->header, seqbuf, sizeof(seqbuf), 0);
 	if ((err = chacha_crypt(&state->header, in, sizeof(buf), buf)) != CRYPT_OK) {
 		return err;

--- a/chachapoly.c
+++ b/chachapoly.c
@@ -122,7 +122,7 @@ static int dropbear_chachapoly_getlength(unsigned int seq,
 	unsigned char seqbuf[8], buf[4];
 	int err;
 
-	TRACE2(("enter dropbear_chachapoly_parse"))
+	TRACE2(("enter dropbear_chachapoly_getlength"))
 
 	if (len < sizeof(buf)) {
 		return CRYPT_ERROR;
@@ -136,7 +136,7 @@ static int dropbear_chachapoly_getlength(unsigned int seq,
 
 	LOAD32H(*outlen, buf);
 
-	TRACE2(("leave dropbear_chachapoly_parse"))
+	TRACE2(("leave dropbear_chachapoly_getlength"))
 	return CRYPT_OK;
 }
 

--- a/gcm.c
+++ b/gcm.c
@@ -100,7 +100,7 @@ static int dropbear_gcm_crypt(unsigned int UNUSED(seq),
 static int dropbear_gcm_getlength(unsigned int UNUSED(seq),
 			const unsigned char *in, unsigned int *outlen,
 			unsigned long len, dropbear_gcm_state* UNUSED(state)) {
-	TRACE2(("enter dropbear_gcm_parse"))
+	TRACE2(("enter dropbear_gcm_getlength"))
 
 	if (len < 4) {
 		return CRYPT_ERROR;
@@ -108,7 +108,7 @@ static int dropbear_gcm_getlength(unsigned int UNUSED(seq),
 
 	LOAD32H(*outlen, in);
 
-	TRACE2(("leave dropbear_gcm_parse"))
+	TRACE2(("leave dropbear_gcm_getlength"))
 	return CRYPT_OK;
 }
 


### PR DESCRIPTION
On 32-bit platforms with old compiler STORE64H() parameter is not auto-expanded to 64-bit value, causing wrong IV data. Spotted on BCM4706 MIPS32r2 with GCC 4.2.4:
```Exit before auth: Integrity error (bad packet size 2065808956)```

Also, fix Chacha20-Poly1305 and AES-GCM trace debug messages, functions were renamed earlier and trace messages - not.