### PR TITLE
Disallow leading lines before the ident for server

### DIFF
--- a/common-session.c
+++ b/common-session.c
@@ -370,8 +370,11 @@ static void read_session_identification() {
 	int len = 0;
 	char done = 0;
 	int i;
-	/* If they send more than 50 lines, something is wrong */
-	for (i = 0; i < 50; i++) {
+
+	/* Servers may send other lines of data before sending the
+	 * version string, client must be able to process such lines.
+	 * If they send more than 50 lines, something is wrong */
+	for (i = IS_DROPBEAR_CLIENT ? 50 : 1; i > 0; i--) {
 		len = ident_readln(ses.sock_in, linebuf, sizeof(linebuf));
 
 		if (len < 0 && errno != EINTR) {


### PR DESCRIPTION
Per RFC4253 4.2 clients must be able to process other lines of data before the version string, server behavior is not defined neither with MUST/SHOULD nor with MAY.
Introducing commit d254e0191d27a98d09373b9df71ff3b13ffda092 (hg: ae4b1bdb29e60927c032674800f0258fc5966807) stated "no harm in letting the server handle it too", but if server process up to 50 lines too - it may cause too long hanging session with invalid/evil client that consume host resources and potentially may lead to DDoS on poor embedded boxes.
Let's require first line from client to be version string (since it's cheap) and fail early if it's not - matches both RFC and real OpenSSH behavior.

