### PR TITLE
libtomcrypt/src/ciphers/rc2.c: resolve potential null pointer derefer…

### DIFF
--- a/libtomcrypt/src/ciphers/rc2.c
+++ b/libtomcrypt/src/ciphers/rc2.c
@@ -68,13 +68,15 @@ static const unsigned char permute[256] = {
  */
 int rc2_setup_ex(const unsigned char *key, int keylen, int bits, int num_rounds, symmetric_key *skey)
 {
-   unsigned *xkey = skey->rc2.xkey;
+   unsigned *xkey;
    unsigned char tmp[128];
    unsigned T8, TM;
    int i;
 
    LTC_ARGCHK(key  != NULL);
    LTC_ARGCHK(skey != NULL);
+
+   xkey = skey->rc2.xkey;
 
    if (keylen == 0 || keylen > 128 || bits > 1024) {
       return CRYPT_INVALID_KEYSIZE;


### PR DESCRIPTION
…ence

found by cppcheck

libtomcrypt/src/ciphers/rc2.c:71:21: warning:
Either the condition 'skey!=NULL' is redundant or there is possible null pointer dereference: skey.
[nullPointerRedundantCheck]