### PR TITLE
configure.ac: add AC_USE_SYSTEM_EXTENSIONS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@
 AC_PREREQ(2.59)
 AC_INIT
 AC_CONFIG_SRCDIR(buffer.c)
+AC_USE_SYSTEM_EXTENSIONS
 
 # Record which revision is being built
 if test -s "`which hg`" && test -d "$srcdir/.hg"; then


### PR DESCRIPTION
Build fails on uclibc since version DROPBEAR_2020.79 and https://github.com/mkj/dropbear/commit/89e98a2f8382bcaab0e7ba04cb4050c9d62898a4:

```
/home/buildroot/autobuild/instance-2/output-1/host/bin/m68k-linux-gcc -c -DLOCALOPTIONS_H_EXISTS -I. -I. -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2 -g2  -fno-dwarf2-cfi-asm  -Wl,-elf2flt -static -Wno-pointer-sign -fno-strict-overflow -DDROPBEAR_SERVER -DPROGRESS_METER -DDBMULTI_dropbear -DDBMULTI_dropbearkey -DDBMULTI_dropbearconvert -DDBMULTI_scp -DDROPBEAR_MULTI -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 dh_groups.c -o dh_groups.o
dbrandom.c: In function 'process_getrandom':
dbrandom.c:174:8: warning: implicit declaration of function 'getrandom'; did you mean 'genrandom'? [-Wimplicit-function-declaration]
  ret = getrandom(buf, sizeof(buf), GRND_NONBLOCK);
        ^~~~~~~~~
        genrandom
/home/buildroot/autobuild/instance-2/output-1/host/bin/m68k-linux-gcc -c -DLOCALOPTIONS_H_EXISTS -I. -I. -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2 -g2  -fno-dwarf2-cfi-asm  -Wl,-elf2flt -static -Wno-pointer-sign -fno-strict-overflow -DDROPBEAR_SERVER -DPROGRESS_METER -DDBMULTI_dropbear -DDBMULTI_dropbearkey -DDBMULTI_dropbearconvert -DDBMULTI_scp -DDROPBEAR_MULTI -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 dropbearconvert.c -o dropbearconvert.o
dbrandom.c:174:36: error: 'GRND_NONBLOCK' undeclared (first use in this function); did you mean 'SOCK_NONBLOCK'?
  ret = getrandom(buf, sizeof(buf), GRND_NONBLOCK);
                                    ^~~~~~~~~~~~~
                                    SOCK_NONBLOCK
```

To fix this build failure, add AC_USE_SYSTEM_EXTENSIONS as getrandom is
only defined if _GNU_SOURCE is set on uclibc

Fixes:
 - http://autobuild.buildroot.org/results/d6d783da2fb834ce21475ff54f82c07873246826

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>