### PR TITLE
signkey: fix use of rsa-sha2-256 pubkeys

### DIFF
--- a/signkey.c
+++ b/signkey.c
@@ -657,8 +657,12 @@ int buf_verify(buffer * buf, sign_key *key, enum signature_type expect_sigtype, 
 	sigtype = signature_type_from_name(type_name, type_name_len);
 	m_free(type_name);
 
-	if (expect_sigtype != sigtype) {
-			dropbear_exit("Non-matching signing type");
+	if (sigtype == DROPBEAR_SIGNATURE_NONE) {
+		dropbear_exit("No signature type");
+	}
+
+	if ((expect_sigtype != DROPBEAR_SIGNATURE_RSA_SHA256) && (expect_sigtype != sigtype)) {
+		dropbear_exit("Non-matching signing type");
 	}
 
 	keytype = signkey_type_from_signature(sigtype);


### PR DESCRIPTION
Commit 972d723484d8 ("split signkey_type and signature_type for RSA sha1
vs sha256") has added strict checking of pubkey algorithms which made
keys with SHA-256 hashing algorithm unusable as they still reuse the
`ssh-rsa` public key format. So fix this by disabling the check for
rsa-sha2-256 pubkeys.

Ref: https://tools.ietf.org/html/rfc8332#section-3
Fixes: 972d723484d8 ("split signkey_type and signature_type for RSA sha1 vs sha256")
Signed-off-by: Petr Štetiar <ynezz@true.cz>