### PR TITLE
Rootless file location support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,10 @@
 /fuzzer-*.options
 /scp
 /scp-progress
-Makefile
 config.h
 config.h.in
 configure
 default_options_guard.h
+localoptions.h
+Makefile
 tags

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+- The following settings conform with DROPBEAR_DEFAULT_CLI_AUTHKEY - home
+  directory is prepended unless there is a leading slash (~/ not recognized). 
+  *_PRIV_FILENAME
+  DROPBEAR_PIDFILE
+  SFTPSERVER_PATH
+
 2020.80 - 26 June 2020
 
 - Don't block authorized_keys logins with no-X11-forwarding or no-agent-forwarding 

--- a/common-runopts.c
+++ b/common-runopts.c
@@ -40,12 +40,14 @@ int readhostkey(const char * filename, sign_key * hostkey,
 
 	int ret = DROPBEAR_FAILURE;
 	buffer *buf;
+  char *expand_path = expand_homedir_path(filename);
 
 	buf = buf_new(MAX_PRIVKEY_SIZE);
 
-	if (buf_readfile(buf, filename) == DROPBEAR_FAILURE) {
+	if (buf_readfile(buf, expand_path) == DROPBEAR_FAILURE) {
 		goto out;
 	}
+  m_free(expand_path);
 	buf_setpos(buf, 0);
 
 	addrandom(buf_getptr(buf, buf->len), buf->len);

--- a/common-runopts.c
+++ b/common-runopts.c
@@ -1,19 +1,19 @@
 /*
  * Dropbear - a SSH2 server
- * 
+ *
  * Copyright (c) 2002,2003 Matt Johnston
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,14 +35,14 @@ runopts opts; /* GLOBAL */
 
 /* returns success or failure, and the keytype in *type. If we want
  * to restrict the type, type can contain a type to return */
-int readhostkey(const char * filename, sign_key * hostkey, 
+int readhostkey(const char * filename, sign_key * hostkey,
 	enum signkey_type *type) {
 
 	int ret = DROPBEAR_FAILURE;
 	buffer *buf;
   char *expand_path = expand_homedir_path(filename);
 
-	buf = buf_new(MAX_PRIVKEY_SIZE);
+  buf = buf_new(MAX_PRIVKEY_SIZE);
 
 	if (buf_readfile(buf, expand_path) == DROPBEAR_FAILURE) {
 		goto out;
@@ -102,5 +102,3 @@ parse_ciphers_macs() {
 void print_version() {
 	fprintf(stderr, "Dropbear v%s\n", DROPBEAR_VERSION);
 }
-
-

--- a/default_options.h
+++ b/default_options.h
@@ -18,7 +18,9 @@ IMPORTANT: Some options will require "make clean" after changes */
 /* Listen on all interfaces */
 #define DROPBEAR_DEFADDRESS ""
 
-/* Default hostkey paths - these can be specified on the command line */
+/* Default hostkey paths - these can be specified on the command line.
+ * Homedir is prepended unless path begins with / .
+ * The ~/ notation is not recognized. */
 #define DSS_PRIV_FILENAME "/etc/dropbear/dropbear_dss_host_key"
 #define RSA_PRIV_FILENAME "/etc/dropbear/dropbear_rsa_host_key"
 #define ECDSA_PRIV_FILENAME "/etc/dropbear/dropbear_ecdsa_host_key"
@@ -220,7 +222,8 @@ group1 in Dropbear server too */
 #define DROPBEAR_CLI_PUBKEY_AUTH 1
 
 /* A default argument for dbclient -i <privatekey>. 
-Homedir is prepended unless path begins with / */
+ * Homedir is prepended unless path begins with / .
+ * The ~/ notation is not recognized. */
 #define DROPBEAR_DEFAULT_CLI_AUTHKEY ".ssh/id_dropbear"
 
 /* Allow specifying the password for dbclient via the DROPBEAR_PASSWORD
@@ -257,7 +260,9 @@ Homedir is prepended unless path begins with / */
 #define MAX_AUTH_TRIES 10
 
 /* The default file to store the daemon's process ID, for shutdown
-   scripts etc. This can be overridden with the -P flag */
+ * scripts etc. This can be overridden with the -P flag.
+ * Homedir is prepended unless path begins with /.
+ * The ~/ notation is not recognized. */
 #define DROPBEAR_PIDFILE "/var/run/dropbear.pid"
 
 /* The command to invoke for xauth when using X11 forwarding.
@@ -265,9 +270,11 @@ Homedir is prepended unless path begins with / */
 #define XAUTH_COMMAND "/usr/bin/xauth -q"
 
 
-/* if you want to enable running an sftp server (such as the one included with
+/* If you want to enable running an sftp server (such as the one included with
  * OpenSSH), set the path below and set DROPBEAR_SFTPSERVER. 
- * The sftp-server program is not provided by Dropbear itself */
+ * The sftp-server program is not provided by Dropbear itself.
+ * Homedir is prepended unless path begins with /.
+ * The ~/ notation is not recognized. */
 #define DROPBEAR_SFTPSERVER 1
 #define SFTPSERVER_PATH "/usr/libexec/sftp-server"
 

--- a/default_options.h
+++ b/default_options.h
@@ -6,7 +6,7 @@
 default_options.h  documents compile-time options, and provides default values.
 
 Local customisation should be added to localoptions.h which is
-used if it exists in the build directory. Options defined there will override 
+used if it exists in the build directory. Options defined there will override
 any options in this file.
 
 Options can also be defined with -DDROPBEAR_XXX=[0,1] in Makefile CFLAGS
@@ -39,7 +39,7 @@ IMPORTANT: Some options will require "make clean" after changes */
 #define NON_INETD_MODE 1
 #define INETD_MODE 1
 
-/* Include verbose debug output, enabled with -v at runtime. 
+/* Include verbose debug output, enabled with -v at runtime.
  * This will add a reasonable amount to your executable size. */
 #define DEBUG_TRACE 0
 
@@ -68,7 +68,7 @@ IMPORTANT: Some options will require "make clean" after changes */
 /* Note: Both DROPBEAR_CLI_PROXYCMD and DROPBEAR_CLI_NETCAT must be set to
  * allow multihop dbclient connections */
 
-/* Allow using -J <proxycommand> to run the connection through a 
+/* Allow using -J <proxycommand> to run the connection through a
    pipe to a program, rather the normal TCP connection */
 #define DROPBEAR_CLI_PROXYCMD 1
 
@@ -82,7 +82,7 @@ IMPORTANT: Some options will require "make clean" after changes */
 /* Encryption - at least one required.
  * AES128 should be enabled, some very old implementations might only
  * support 3DES.
- * Including both AES keysize variants (128 and 256) will result in 
+ * Including both AES keysize variants (128 and 256) will result in
  * a minimal size increase */
 #define DROPBEAR_AES128 1
 #define DROPBEAR_AES256 1
@@ -119,17 +119,20 @@ IMPORTANT: Some options will require "make clean" after changes */
 /* Hostkey/public key algorithms - at least one required, these are used
  * for hostkey as well as for verifying signatures with pubkey auth.
  * Removing either of these won't save very much space.
- * RSA is recommended
+ * RSA is recommended.
  * DSS may be necessary to connect to some systems though
-   is not recommended for new keys */
+ * is not recommended for new keys.
+ * See: RSA_PRIV_FILENAME and DSS_PRIV_FILENAME */
 #define DROPBEAR_RSA 1
 #define DROPBEAR_DSS 1
 /* ECDSA is significantly faster than RSA or DSS. Compiling in ECC
  * code (either ECDSA or ECDH) increases binary size - around 30kB
- * on x86-64 */
+ * on x86-64.
+ * See: ECDSA_PRIV_FILENAME  */
 #define DROPBEAR_ECDSA 1
 /* Ed25519 is faster than ECDSA. Compiling in Ed25519 code increases
-   binary size - around 7,5kB on x86-64 */
+ * binary size - around 7,5kB on x86-64.
+ * See: ED25519_PRIV_FILENAME  */
 #define DROPBEAR_ED25519 1
 
 /* RSA must be >=1024 */
@@ -205,7 +208,8 @@ group1 in Dropbear server too */
  * You can't enable both PASSWORD and PAM. */
 #define DROPBEAR_SVR_PAM_AUTH 0
 
-/* ~/.ssh/authorized_keys authentication */
+/* ~/.ssh/authorized_keys authentication.
+ * You must define DROPBEAR_SVR_PUBKEY_AUTH in order to use plugins. */
 #define DROPBEAR_SVR_PUBKEY_AUTH 1
 
 /* Whether to take public key options in 
@@ -221,7 +225,7 @@ group1 in Dropbear server too */
 #define DROPBEAR_CLI_PASSWORD_AUTH 1
 #define DROPBEAR_CLI_PUBKEY_AUTH 1
 
-/* A default argument for dbclient -i <privatekey>. 
+/* A default argument for dbclient -i <privatekey>.
  * Homedir is prepended unless path begins with / .
  * The ~/ notation is not recognized. */
 #define DROPBEAR_DEFAULT_CLI_AUTHKEY ".ssh/id_dropbear"
@@ -271,7 +275,7 @@ group1 in Dropbear server too */
 
 
 /* If you want to enable running an sftp server (such as the one included with
- * OpenSSH), set the path below and set DROPBEAR_SFTPSERVER. 
+ * OpenSSH), set the path below and set DROPBEAR_SFTPSERVER.
  * The sftp-server program is not provided by Dropbear itself.
  * Homedir is prepended unless path begins with /.
  * The ~/ notation is not recognized. */

--- a/default_options.h
+++ b/default_options.h
@@ -192,7 +192,11 @@ group1 in Dropbear server too */
 /* Whether to do reverse DNS lookups. */
 #define DO_HOST_LOOKUP 0
 
-/* Whether to print the message of the day (MOTD). */
+/* Whether to print the message of the day (MOTD). 
+ * The MOTD is not shown when
+ * DROPBEAR_SVR_PASSWORD_AUTH 0
+ * DROPBEAR_SVR_PAM_AUTH 0
+ * DROPBEAR_SVR_PUBKEY_AUTH 1. */
 #define DO_MOTD 1
 #define MOTD_FILENAME "/etc/motd"
 

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -854,8 +854,9 @@ static int ptycommand(struct Channel *channel, struct ChanSess *chansess) {
 
 			if (stat(hushpath, &sb) < 0) {
 				/* more than a screenful is stupid IMHO */
-				motdbuf = buf_new(80 * 25);
-				if (buf_readfile(motdbuf, MOTD_FILENAME) == DROPBEAR_SUCCESS) {
+				motdbuf = buf_new(80 * 25);        
+        char *expand_path = expand_homedir_path(MOTD_FILENAME);
+				if (buf_readfile(motdbuf, expand_path) == DROPBEAR_SUCCESS) {
 					buf_setpos(motdbuf, 0);
 					while (motdbuf->pos != motdbuf->len) {
 						len = motdbuf->len - motdbuf->pos;
@@ -864,7 +865,9 @@ static int ptycommand(struct Channel *channel, struct ChanSess *chansess) {
 						buf_incrpos(motdbuf, len);
 					}
 				}
+        m_free(expand_path);
 				buf_free(motdbuf);
+
 			}
 			m_free(hushpath);
 		}

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -680,7 +680,9 @@ static int sessioncommand(struct Channel *channel, struct ChanSess *chansess,
 #if DROPBEAR_SFTPSERVER
 			if ((cmdlen == 4) && strncmp(chansess->cmd, "sftp", 4) == 0) {
 				m_free(chansess->cmd);
-				chansess->cmd = m_strdup(SFTPSERVER_PATH);
+        char *expand_path = expand_homedir_path(SFTPSERVER_PATH);
+				chansess->cmd = m_strdup(expand_path);
+        m_free(expand_path);
 			} else 
 #endif
 			{

--- a/svr-kex.c
+++ b/svr-kex.c
@@ -160,8 +160,7 @@ static void svr_ensure_hostkey() {
 		buf_setpos(key_buf, 4);
 		len = key_buf->len - key_buf->pos;
 		fp = sign_key_fingerprint(buf_getptr(key_buf, len), len);
-		dropbear_log(LOG_INFO, "Generated hostkey %s, fingerprint is %s",
-			fn, fp);
+		dropbear_log(LOG_INFO, "Generated hostkey fingerprint is %s", fp);
 		m_free(fp);
 		buf_free(key_buf);
 	}

--- a/svr-kex.c
+++ b/svr-kex.c
@@ -135,7 +135,7 @@ static void svr_ensure_hostkey() {
 #endif
 #if DROPBEAR_ED25519
 		case DROPBEAR_SIGNKEY_ED25519:
-			fn = ED25519_PRIV_FILENAME;
+      fn = ED25519_PRIV_FILENAME;
 			break;
 #endif
 		default:

--- a/svr-runopts.c
+++ b/svr-runopts.c
@@ -162,7 +162,7 @@ void svr_getopts(int argc, char ** argv) {
 	svr_opts.portcount = 0;
 	svr_opts.hostkey = NULL;
 	svr_opts.delay_hostkey = 0;
-	svr_opts.pidfile = DROPBEAR_PIDFILE;
+	svr_opts.pidfile = expand_homedir_path(DROPBEAR_PIDFILE);
 #if DROPBEAR_SVR_LOCALTCPFWD
 	svr_opts.nolocaltcp = 0;
 #endif
@@ -508,12 +508,14 @@ static void loadhostkey_helper(const char *name, void** src, void** dst, int fat
 /* Must be called after syslog/etc is working */
 static void loadhostkey(const char *keyfile, int fatal_duplicate) {
 	sign_key * read_key = new_sign_key();
+  char *expand_path = expand_homedir_path(keyfile);
 	enum signkey_type type = DROPBEAR_SIGNKEY_ANY;
-	if (readhostkey(keyfile, read_key, &type) == DROPBEAR_FAILURE) {
+	if (readhostkey(expand_path, read_key, &type) == DROPBEAR_FAILURE) {
 		if (!svr_opts.delay_hostkey) {
-			dropbear_log(LOG_WARNING, "Failed loading %s", keyfile);
+			dropbear_log(LOG_WARNING, "Failed loading %s", expand_path);
 		}
 	}
+  m_free(expand_path);
 
 #if DROPBEAR_RSA
 	if (type == DROPBEAR_SIGNKEY_RSA) {


### PR DESCRIPTION
Tried to keep changes to a minimum.
Not sure what guides you... For our rootless build (excl zlib) `size` says  280 bytes extra while `ls -la` says 48 bytes extra. 

Sizes at `88f63b8b0f13`:
```bash
$ size dropbearmulti
    text    data     bss     dec     hex filename
  228047    1448    7728  237223   39ea7 dropbearmulti
```
`ls -la` says: 271,104 bytes

 Sizes at `1c24c9cf1d76`:
 ```bash
$ size dropbearmulti
    text    data     bss     dec     hex filename
  228327    1448    7728  237503   39fbf dropbearmulti
```
 `ls -la` says: 271,152 bytes

Commit message:
```
Why:
Running dropbear as a user (rootless) is aided if
files and programs can be saved/removed without
needing sudo.

What:
Use the same convention as DROPBEAR_DEFAULT_CLI_AUTHKEY;
if not starting with '/', then is relative to <user>'s /home/<user>:
*_PRIV_FILENAME
DROPBEAR_PIDFILE
SFTPSERVER_PATH

default_options.h commentary added.

Changes kept to a minimum, so log entry in svr_kex.c#163
is refactored.
From:
    Generated hostkey is <path> ... <finger-print>
to:
    Generated hostkey path is <path>
    Generated hostkey fingerprint is <fp>
Otherwise the unexpanded path was reported.
```