### PR TITLE
keep LANG env variable for child process

### DIFF
--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -920,6 +920,11 @@ static void addchildpid(struct ChanSess *chansess, pid_t pid) {
 static void execchild(const void *user_data) {
 	const struct ChanSess *chansess = user_data;
 	char *usershell = NULL;
+	char *cp = NULL;
+	char *envcp = getenv("LANG");
+	if (envcp != NULL) {
+		cp = m_strdup(envcp);
+	}
 
 	/* with uClinux we'll have vfork()ed, so don't want to overwrite the
 	 * hostkey. can't think of a workaround to clear it */
@@ -978,6 +983,10 @@ static void execchild(const void *user_data) {
 	addnewvar("HOME", ses.authstate.pw_dir);
 	addnewvar("SHELL", get_user_shell());
 	addnewvar("PATH", DEFAULT_PATH);
+	if (cp != NULL) {
+		addnewvar("LANG", cp);
+		m_free(cp);
+	}	
 	if (chansess->term != NULL) {
 		addnewvar("TERM", chansess->term);
 	}


### PR DESCRIPTION
When gesftpserver is used as sftp server, it needs LANG variable to proper convert UTF-8 based filenames.
OpenSSH keep this variable for child process:
https://github.com/openssh/openssh-portable/blob/master/auth.c#L921