### PR TITLE
Fix handling of replies to global requests

### DIFF
--- a/cli-session.c
+++ b/cli-session.c
@@ -408,9 +408,19 @@ void cleantext(char* dirtytext) {
 }
 
 static void recv_msg_global_request_cli(void) {
-	TRACE(("recv_msg_global_request_cli"))
-	/* Send a proper rejection */
-	send_msg_request_failure();
+	unsigned int len = 0;
+	unsigned int wantreply = 0;
+
+	len = buf_getint(ses.payload);
+	buf_incrpos(ses.payload, len);
+	wantreply = buf_getbool(ses.payload);
+
+	TRACE(("recv_msg_global_request_cli: want_reply: %u", wantreply));
+
+	if (wantreply) {
+		/* Send a proper rejection */
+		send_msg_request_failure();
+	}
 }
 
 void cli_dropbear_exit(int exitcode, const char* format, va_list param) {

--- a/svr-tcpfwd.c
+++ b/svr-tcpfwd.c
@@ -39,8 +39,17 @@
 
 /* This is better than SSH_MSG_UNIMPLEMENTED */
 void recv_msg_global_request_remotetcp() {
-		TRACE(("recv_msg_global_request_remotetcp: remote tcp forwarding not compiled in"))
+	unsigned int len = 0;
+	unsigned int wantreply = 0;
+
+	TRACE(("recv_msg_global_request_remotetcp: remote tcp forwarding not compiled in"))
+
+	len = buf_getint(ses.payload);
+	buf_incrpos(ses.payload, len);
+	wantreply = buf_getbool(ses.payload);
+	if (wantreply) {
 		send_msg_request_failure();
+	}
 }
 
 /* */


### PR DESCRIPTION
The current code assumes that all global requests want / need a reply. This isn't always true and the request itself indicates if it wants a reply or not.

It causes a specific problem with `hostkeys-00@openssh.com` messages. These are sent by OpenSSH after authentication to inform the client of potential other host keys for the host. This can be used to add a new type of host key or to rotate host keys.

The initial information message from the server is sent as a global request, but with want_reply set to false. This means that the server doesn't expect an answer to this message. Instead the client needs to send a prove request as a reply if it wants to receive proof of ownership for the host keys.

The bug doesn't cause any current problems with due to how OpenSSH treats receiving the failure message. It instead treats it as a keepalive message and further ignores it.

Arguably this is a protocol violation though of Dropbear and it is only accidental that it doesn't cause a problem with OpenSSH.

The bug was found when adding host keys support to libssh, which is more strict protocol wise and treats the unexpected failure message an error, also see https://gitlab.com/libssh/libssh-mirror/-/merge_requests/145 for more information.

The fix here is to honor the want_reply flag in the global request and to only send a reply if the other side expects a reply.