### PR TITLE
pass on sever process environment to child processes (option -e)

### DIFF
--- a/dropbear.8
+++ b/dropbear.8
@@ -35,6 +35,11 @@ Don't fork into background.
 .B \-E
 Log to standard error rather than syslog.
 .TP
+.B \-e
+Pass on the server environment to all child processes. This is required, for example,
+if dropbear is launched on the fly from a SLURM workload manager. The enviroment is not
+passed by default. Note that this can be a potential security risk.
+.TP
 .B \-m
 Don't display the message of the day on login.
 .TP

--- a/runopts.h
+++ b/runopts.h
@@ -130,6 +130,8 @@ typedef struct svr_runopts {
         char *pubkey_plugin_options;
 #endif
 
+	int pass_on_env;
+
 } svr_runopts;
 
 extern svr_runopts svr_opts;

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -940,19 +940,21 @@ static void execchild(const void *user_data) {
 	seedrandom();
 #endif
 
-	/* clear environment */
+	/* clear environment if -e was not set */
 	/* if we're debugging using valgrind etc, we need to keep the LD_PRELOAD
 	 * etc. This is hazardous, so should only be used for debugging. */
+	if ( !svr_opts.pass_on_env) {
 #ifndef DEBUG_VALGRIND
 #ifdef HAVE_CLEARENV
-	clearenv();
+		clearenv();
 #else /* don't HAVE_CLEARENV */
-	/* Yay for posix. */
-	if (environ) {
-		environ[0] = NULL;
-	}
+		/* Yay for posix. */
+		if (environ) {
+			environ[0] = NULL;
+		}
 #endif /* HAVE_CLEARENV */
 #endif /* DEBUG_VALGRIND */
+	}
 
 #if DROPBEAR_SVR_MULTIUSER
 	/* We can only change uid/gid as root ... */

--- a/svr-runopts.c
+++ b/svr-runopts.c
@@ -64,6 +64,7 @@ static void printhelp(const char * progname) {
 					"-R		Create hostkeys as required\n" 
 #endif
 					"-F		Don't fork into background\n"
+					"-e		Pass on server process environment to child process\n"
 #ifdef DISABLE_SYSLOG
 					"(Syslog support not compiled in, using stderr)\n"
 #else
@@ -173,6 +174,7 @@ void svr_getopts(int argc, char ** argv) {
         svr_opts.pubkey_plugin = NULL;
         svr_opts.pubkey_plugin_options = NULL;
 #endif
+	svr_opts.pass_on_env = 0;
 
 #ifndef DISABLE_ZLIB
 	opts.compress_mode = DROPBEAR_COMPRESS_DELAYED;
@@ -223,6 +225,10 @@ void svr_getopts(int argc, char ** argv) {
 					opts.usingsyslog = 0;
 					break;
 #endif
+				case 'e':
+					svr_opts.pass_on_env = 1;
+					break;
+
 #if DROPBEAR_SVR_LOCALTCPFWD
 				case 'j':
 					svr_opts.nolocaltcp = 1;


### PR DESCRIPTION
The environment of the ssh server process is usually cleared and not passed on to the child process for security reasons. However, in certain situations it may be desirable to inherit the server environment. For example: I start dropbear (as non-root) from a SLURM workload manager, which exposes a lot variables containing of information about the confined runtime environment. These need to be inherited by child processes which are also subject to SLURM's runtime environment. 