### PR TITLE
Remove unused argument of do_cmd() in scp.c

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -185,7 +185,7 @@ arg_setup(char *host, char *remuser, char *cmd)
 }
 
 int
-do_cmd(char *host, char *remuser, char *cmd, int *fdin, int *fdout, int argc)
+do_cmd(char *host, char *remuser, char *cmd, int *fdin, int *fdout)
 {
 	int pin[2], pout[2], reserved[2];
 
@@ -532,8 +532,7 @@ toremote(char *targ, int argc, char **argv)
 				bp = xmalloc(len);
 				(void) snprintf(bp, len, "%s -t %s", cmd, targ);
 				host = cleanhostname(thost);
-				if (do_cmd(host, tuser, bp, &remin,
-				    &remout, argc) < 0)
+				if (do_cmd(host, tuser, bp, &remin, &remout) < 0)
 					exit(1);
 				if (response() < 0)
 					exit(1);
@@ -584,7 +583,7 @@ tolocal(int argc, char **argv)
 		len = strlen(src) + CMDNEEDS + 20;
 		bp = xmalloc(len);
 		(void) snprintf(bp, len, "%s -f %s", cmd, src);
-		if (do_cmd(host, suser, bp, &remin, &remout, argc) < 0) {
+		if (do_cmd(host, suser, bp, &remin, &remout) < 0) {
 			(void) xfree(bp);
 			++errs;
 			continue;


### PR DESCRIPTION
This simply removes the following warning logged because the 6-th argument `int argc` is not used.

```
gcc -c -I./libtomcrypt/src/headers/ -I. -I.  -Os -W -Wall -Wno-pointer-sign -fno-strict-overflow -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2 -DDROPBEAR_SERVER -DDROPBEAR_CLIENT  scp.c -o scp.o
scp.c: In function ‘do_cmd’:
scp.c:188:73: warning: unused parameter ‘argc’ [-Wunused-parameter]
  188 | do_cmd(char *host, char *remuser, char *cmd, int *fdin, int *fdout, int argc)
      |                                                                     ~~~~^~~~
```