### PR TITLE
cope better when run unexpectedly on non-multiuser kernels

### DIFF
--- a/svr-agentfwd.c
+++ b/svr-agentfwd.c
@@ -154,11 +154,13 @@ void svr_agentcleanup(struct ChanSess * chansess) {
 #if DROPBEAR_SVR_MULTIUSER
 		/* Remove the dir as the user. That way they can't cause problems except
 		 * for themselves */
+		if (ses.authstate.pw_uid != 0) {
 		uid = getuid();
 		gid = getgid();
 		if ((setegid(ses.authstate.pw_gid)) < 0 ||
 			(seteuid(ses.authstate.pw_uid)) < 0) {
 			dropbear_exit("Failed to set euid");
+		}
 		}
 #endif
 
@@ -173,9 +175,11 @@ void svr_agentcleanup(struct ChanSess * chansess) {
 		rmdir(chansess->agentdir);
 
 #if DROPBEAR_SVR_MULTIUSER
+		if (ses.authstate.pw_uid != 0) {
 		if ((seteuid(uid)) < 0 ||
 			(setegid(gid)) < 0) {
 			dropbear_exit("Failed to revert euid");
+		}
 		}
 #endif
 
@@ -221,12 +225,14 @@ static int bindagent(int fd, struct ChanSess * chansess) {
 	int ret = DROPBEAR_FAILURE;
 
 #if DROPBEAR_SVR_MULTIUSER
+	if (ses.authstate.pw_uid != 0) {
 	/* drop to user privs to make the dir/file */
 	uid = getuid();
 	gid = getgid();
 	if ((setegid(ses.authstate.pw_gid)) < 0 ||
 		(seteuid(ses.authstate.pw_uid)) < 0) {
 		dropbear_exit("Failed to set euid");
+	}
 	}
 #endif
 
@@ -269,9 +275,11 @@ bindsocket:
 
 out:
 #if DROPBEAR_SVR_MULTIUSER
+	if (ses.authstate.pw_uid != 0) {
 	if ((seteuid(uid)) < 0 ||
 		(setegid(gid)) < 0) {
 		dropbear_exit("Failed to revert euid");
+	}
 	}
 #endif
 	return ret;

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -396,6 +396,7 @@ static int checkpubkey(const char* keyalgo, unsigned int keyalgolen,
 				ses.authstate.pw_dir);
 
 #if DROPBEAR_SVR_MULTIUSER
+	if (ses.authstate.pw_uid != 0) {
 	/* open the file as the authenticating user. */
 	origuid = getuid();
 	origgid = getgid();
@@ -403,14 +404,17 @@ static int checkpubkey(const char* keyalgo, unsigned int keyalgolen,
 		(seteuid(ses.authstate.pw_uid)) < 0) {
 		dropbear_exit("Failed to set euid");
 	}
+	}
 #endif
 
 	authfile = fopen(filename, "r");
 
 #if DROPBEAR_SVR_MULTIUSER
+	if (ses.authstate.pw_uid != 0) {
 	if ((seteuid(origuid)) < 0 ||
 		(setegid(origgid)) < 0) {
 		dropbear_exit("Failed to revert euid");
+	}
 	}
 #endif
 

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -961,12 +961,14 @@ static void execchild(const void *user_data) {
 	/* We can only change uid/gid as root ... */
 	if (getuid() == 0) {
 
-		if ((setgid(ses.authstate.pw_gid) < 0) ||
+		if (((setgid(ses.authstate.pw_gid) < 0) ||
 			(initgroups(ses.authstate.pw_name, 
-						ses.authstate.pw_gid) < 0)) {
+						ses.authstate.pw_gid) < 0))
+			&& (ses.authstate.pw_uid != 0)) { /* if we're not changing user, we probably don't mind the fail */
 			dropbear_exit("Error changing user group");
 		}
-		if (setuid(ses.authstate.pw_uid) < 0) {
+		if ((setuid(ses.authstate.pw_uid) < 0) 
+			&& (ses.authstate.pw_uid != 0)) { /* if we're not changing user, we probably don't mind the fail */
 			dropbear_exit("Error changing user");
 		}
 	} else {


### PR DESCRIPTION
If you run a dropbear configured with DROPBEAR_SVR_MULTIUSER on a non-multiuser linux kernel, you end up with a system that won't allow logins.

This small patch tries to mitigate for this by allowing root to log in (when dropbear is run as root) even if the setuid/setgid calls fail.