### PR TITLE
added option to disable trivial auth methods

### DIFF
--- a/cli-auth.c
+++ b/cli-auth.c
@@ -261,6 +261,9 @@ void recv_msg_userauth_success() {
 	if DROPBEAR_CLI_IMMEDIATE_AUTH is set */
 
 	TRACE(("received msg_userauth_success"))
+	if (cli_opts.exit_on_trivial_auth && cli_ses.is_trivial_auth) {
+		dropbear_exit("trivial authentication not allowed");
+	}
 	/* Note: in delayed-zlib mode, setting authdone here 
 	 * will enable compression in the transport layer */
 	ses.authstate.authdone = 1;

--- a/cli-auth.c
+++ b/cli-auth.c
@@ -261,7 +261,7 @@ void recv_msg_userauth_success() {
 	if DROPBEAR_CLI_IMMEDIATE_AUTH is set */
 
 	TRACE(("received msg_userauth_success"))
-	if (cli_opts.exit_on_trivial_auth && cli_ses.is_trivial_auth) {
+	if (cli_opts.disable_trivial_auth && cli_ses.is_trivial_auth) {
 		dropbear_exit("trivial authentication not allowed");
 	}
 	/* Note: in delayed-zlib mode, setting authdone here 

--- a/cli-authinteract.c
+++ b/cli-authinteract.c
@@ -114,6 +114,7 @@ void recv_msg_userauth_info_request() {
 	m_free(instruction);
 
 	for (i = 0; i < num_prompts; i++) {
+		cli_ses.is_trivial_auth = 0;
 		unsigned int response_len = 0;
 		prompt = buf_getstring(ses.payload, NULL);
 		cleantext(prompt);

--- a/cli-authpasswd.c
+++ b/cli-authpasswd.c
@@ -155,7 +155,7 @@ void cli_auth_password() {
 
 	encrypt_packet();
 	m_burn(password, strlen(password));
-
+	cli_ses.is_trivial_auth = 0;
 	TRACE(("leave cli_auth_password"))
 }
 #endif	/* DROPBEAR_CLI_PASSWORD_AUTH */

--- a/cli-authpubkey.c
+++ b/cli-authpubkey.c
@@ -176,6 +176,7 @@ static void send_msg_userauth_pubkey(sign_key *key, enum signature_type sigtype,
 		buf_putbytes(sigbuf, ses.writepayload->data, ses.writepayload->len);
 		cli_buf_put_sign(ses.writepayload, key, sigtype, sigbuf);
 		buf_free(sigbuf); /* Nothing confidential in the buffer */
+		cli_ses.is_trivial_auth = 0;
 	}
 
 	encrypt_packet();
@@ -266,7 +267,6 @@ int cli_auth_pubkey() {
 		/* Send a trial request */
 		send_msg_userauth_pubkey(key, sigtype, 0);
 		cli_ses.lastprivkey = key;
-		cli_ses.is_trivial_auth = 0;
 		TRACE(("leave cli_auth_pubkey-success"))
 		return 1;
 	} else {

--- a/cli-authpubkey.c
+++ b/cli-authpubkey.c
@@ -266,6 +266,7 @@ int cli_auth_pubkey() {
 		/* Send a trial request */
 		send_msg_userauth_pubkey(key, sigtype, 0);
 		cli_ses.lastprivkey = key;
+		cli_ses.is_trivial_auth = 0;
 		TRACE(("leave cli_auth_pubkey-success"))
 		return 1;
 	} else {

--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -152,6 +152,7 @@ void cli_getopts(int argc, char ** argv) {
 #if DROPBEAR_CLI_ANYTCPFWD
 	cli_opts.exit_on_fwd_failure = 0;
 #endif
+	cli_opts.exit_on_trivial_auth = 0;
 #if DROPBEAR_CLI_LOCALTCPFWD
 	cli_opts.localfwds = list_new();
 	opts.listen_fwd_all = 0;
@@ -889,6 +890,7 @@ static void add_extendedopt(const char* origstr) {
 #if DROPBEAR_CLI_ANYTCPFWD
 			"\tExitOnForwardFailure\n"
 #endif
+			"\tExitOnTrivialAuth\n"
 #ifndef DISABLE_SYSLOG
 			"\tUseSyslog\n"
 #endif
@@ -913,6 +915,11 @@ static void add_extendedopt(const char* origstr) {
 
 	if (match_extendedopt(&optstr, "Port") == DROPBEAR_SUCCESS) {
 		cli_opts.remoteport = optstr;
+		return;
+	}
+
+	if (match_extendedopt(&optstr, "ExitOnTrivialAuth") == DROPBEAR_SUCCESS) {
+		cli_opts.exit_on_trivial_auth = parse_flag_value(optstr);
 		return;
 	}
 

--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -152,7 +152,7 @@ void cli_getopts(int argc, char ** argv) {
 #if DROPBEAR_CLI_ANYTCPFWD
 	cli_opts.exit_on_fwd_failure = 0;
 #endif
-	cli_opts.exit_on_trivial_auth = 0;
+	cli_opts.disable_trivial_auth = 0;
 #if DROPBEAR_CLI_LOCALTCPFWD
 	cli_opts.localfwds = list_new();
 	opts.listen_fwd_all = 0;
@@ -890,7 +890,7 @@ static void add_extendedopt(const char* origstr) {
 #if DROPBEAR_CLI_ANYTCPFWD
 			"\tExitOnForwardFailure\n"
 #endif
-			"\tExitOnTrivialAuth\n"
+			"\tDisableTrivialAuth\n"
 #ifndef DISABLE_SYSLOG
 			"\tUseSyslog\n"
 #endif
@@ -918,8 +918,8 @@ static void add_extendedopt(const char* origstr) {
 		return;
 	}
 
-	if (match_extendedopt(&optstr, "ExitOnTrivialAuth") == DROPBEAR_SUCCESS) {
-		cli_opts.exit_on_trivial_auth = parse_flag_value(optstr);
+	if (match_extendedopt(&optstr, "DisableTrivialAuth") == DROPBEAR_SUCCESS) {
+		cli_opts.disable_trivial_auth = parse_flag_value(optstr);
 		return;
 	}
 

--- a/cli-session.c
+++ b/cli-session.c
@@ -165,6 +165,7 @@ static void cli_session_init(pid_t proxy_cmd_pid) {
 	/* Auth */
 	cli_ses.lastprivkey = NULL;
 	cli_ses.lastauthtype = 0;
+	cli_ses.is_trivial_auth = 1;
 
 	/* For printing "remote host closed" for the user */
 	ses.remoteclosed = cli_remoteclosed;

--- a/runopts.h
+++ b/runopts.h
@@ -159,6 +159,7 @@ typedef struct cli_runopts {
 #if DROPBEAR_CLI_ANYTCPFWD
 	int exit_on_fwd_failure;
 #endif
+	int exit_on_trivial_auth;
 #if DROPBEAR_CLI_REMOTETCPFWD
 	m_list * remotefwds;
 #endif

--- a/runopts.h
+++ b/runopts.h
@@ -159,7 +159,7 @@ typedef struct cli_runopts {
 #if DROPBEAR_CLI_ANYTCPFWD
 	int exit_on_fwd_failure;
 #endif
-	int exit_on_trivial_auth;
+	int disable_trivial_auth;
 #if DROPBEAR_CLI_REMOTETCPFWD
 	m_list * remotefwds;
 #endif

--- a/session.h
+++ b/session.h
@@ -316,6 +316,7 @@ struct clientsession {
 
 	int lastauthtype; /* either AUTH_TYPE_PUBKEY or AUTH_TYPE_PASSWORD,
 						 for the last type of auth we tried */
+	int is_trivial_auth;
 	int ignore_next_auth_response;
 #if DROPBEAR_CLI_INTERACT_AUTH
 	int auth_interact_failed; /* flag whether interactive auth can still


### PR DESCRIPTION
I have added an option ``-o ExitOnTrivialAuth=yes`` to disable trivial authentications as discussed in our mails