### PR TITLE
signkey: remove !! from SHA1 digest

### DIFF
--- a/signkey.c
+++ b/signkey.c
@@ -568,7 +568,7 @@ static char * sign_key_sha1_fingerprint(const unsigned char* keyblob,
 	buflen = 7 + 3*SHA1_HASH_SIZE;
 	ret = (char*)m_malloc(buflen);
 
-	strcpy(ret, "sha1!! ");
+	strcpy(ret, "sha1 ");
 
 	for (i = 0; i < SHA1_HASH_SIZE; i++) {
 		unsigned int pos = 7 + 3*i;


### PR DESCRIPTION
Remove the "!!" chars from message when printing the key-fingerprint, as it's confusing users (#116). They have been added when switching from MD5, but SHA1 can be considered as standard today.
