### PR TITLE
dbclient: Use HOME in preference to /etc/passwd when locating default authentication key

### DIFF
--- a/dbutil.c
+++ b/dbutil.c
@@ -602,11 +602,19 @@ otherwise home directory is prepended */
 char * expand_homedir_path(const char *inpath) {
 	struct passwd *pw = NULL;
 	if (inpath[0] != '/') {
-		pw = getpwuid(getuid());
-		if (pw && pw->pw_dir) {
-			int len = strlen(inpath) + strlen(pw->pw_dir) + 2;
+		char *homedir = getenv("HOME");
+
+		if (!homedir) {
+			pw = getpwuid(getuid());
+			if (pw) {
+				homedir = pw->pw_dir;
+			}
+		}
+
+		if (homedir) {
+			int len = strlen(inpath) + strlen(homedir) + 2;
 			char *buf = m_malloc(len);
-			snprintf(buf, len, "%s/%s", pw->pw_dir, inpath);
+			snprintf(buf, len, "%s/%s", homedir, inpath);
 			return buf;
 		}
 	}


### PR DESCRIPTION
Currently `dbclient` uses the value of `HOME` by default when looking for `~/.ssh/known_hosts`, falling back to `/etc/passwd` if `HOME` is not set (so that people can work around broken values in `/etc/passwd`).

However, when locating the default authentication key (defaults to `~/.ssh/id_dropbear`), paths not starting with / are always prefixed with the value from `/etc/passwd`.

Make the behaviour consistent by adjusting `expand_homedir_path` to use the value of `HOME`, falling back to `/etc/passwd` if `HOME` is not set.