### PR TITLE
Additional DEBUG_LEVEL messages for dbclient

### DIFF
--- a/cli-auth.c
+++ b/cli-auth.c
@@ -260,7 +260,7 @@ void recv_msg_userauth_success() {
 	/* This function can validly get called multiple times
 	if DROPBEAR_CLI_IMMEDIATE_AUTH is set */
 
-	TRACE(("received msg_userauth_success"))
+	TRACELEVEL((1,"received msg_userauth_success"))
 	if (cli_opts.disable_trivial_auth && cli_ses.is_trivial_auth) {
 		dropbear_exit("trivial authentication not allowed");
 	}

--- a/cli-authpasswd.c
+++ b/cli-authpasswd.c
@@ -120,7 +120,7 @@ void cli_auth_password() {
 	char* password = NULL;
 	char prompt[80];
 
-	TRACE(("enter cli_auth_password"))
+	TRACELEVEL((1,"enter cli_auth_password"))
 	CHECKCLEARTOWRITE();
 
 	snprintf(prompt, sizeof(prompt), "%s@%s's password: ", 

--- a/cli-authpubkey.c
+++ b/cli-authpubkey.c
@@ -147,7 +147,8 @@ static void send_msg_userauth_pubkey(sign_key *key, enum signature_type sigtype,
 	buffer* sigbuf = NULL;
 	enum signkey_type keytype = signkey_type_from_signature(sigtype);
 
-	TRACE(("enter send_msg_userauth_pubkey sigtype %d", sigtype))
+	// TRACE(("enter send_msg_userauth_pubkey sigtype %d", sigtype))
+	TRACELEVEL((1,"enter send_msg_userauth_pubkey %s", signkey_name_from_type(sigtype,NULL)))
 	CHECKCLEARTOWRITE();
 
 	buf_putbyte(ses.writepayload, SSH_MSG_USERAUTH_REQUEST);

--- a/cli-main.c
+++ b/cli-main.c
@@ -66,10 +66,10 @@ int main(int argc, char ** argv) {
 #endif
 
         if (cli_opts.bind_address) {
-		TRACELEVEL((1,"connect to: user=%s host=%s:%s bind_address=%s:%s", cli_opts.username,
+		TRACELEVEL((1,"connect to: user=%s host=%s/%s bind_address=%s:%s", cli_opts.username,
 			cli_opts.remotehost, cli_opts.remoteport, cli_opts.bind_address, cli_opts.bind_port))
 	} else {
-		TRACELEVEL((1,"connect to: user=%s host=%s:%s",cli_opts.username,cli_opts.remotehost,cli_opts.remoteport))
+		TRACELEVEL((1,"connect to: user=%s host=%s/%s",cli_opts.username,cli_opts.remotehost,cli_opts.remoteport))
 	}
 
 	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {

--- a/cli-main.c
+++ b/cli-main.c
@@ -65,8 +65,12 @@ int main(int argc, char ** argv) {
 	}
 #endif
 
-	TRACE(("user='%s' host='%s' port='%s' bind_address='%s' bind_port='%s'", cli_opts.username,
-				cli_opts.remotehost, cli_opts.remoteport, cli_opts.bind_address, cli_opts.bind_port))
+        if (cli_opts.bind_address) {
+		TRACELEVEL((1,"connect to: user=%s host=%s:%s bind_address=%s:%s", cli_opts.username,
+			cli_opts.remotehost, cli_opts.remoteport, cli_opts.bind_address, cli_opts.bind_port))
+	} else {
+		TRACELEVEL((1,"connect to: user=%s host=%s:%s",cli_opts.username,cli_opts.remotehost,cli_opts.remoteport))
+	}
 
 	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
 		dropbear_exit("signal() error");
@@ -135,6 +139,7 @@ static void cli_proxy_cmd(int *sock_in, int *sock_out, pid_t *pid_out) {
 
 	ret = spawn_command(exec_proxy_cmd, ex_cmd,
 			sock_out, sock_in, NULL, pid_out);
+	TRACELEVEL((1,"cmd: %s  pid=%d", ex_cmd,*pid_out))
 	m_free(ex_cmd);
 	if (ret == DROPBEAR_FAILURE) {
 		dropbear_exit("Failed running proxy command");

--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -301,7 +301,11 @@ void cli_getopts(int argc, char ** argv) {
 #endif
 #if DEBUG_LEVEL
 				case 'v':
+#if DEBUG_TRACE
+					debug_trace=9;
+#else
 					debug_trace++;
+#endif
 					break;
 #endif
 				case 'F':
@@ -560,6 +564,24 @@ multihop_passthrough_args() {
 		int written = snprintf(ret+total, len-total, "-W %u ", opts.recv_window);
 		total += written;
 	}
+#if DEBUG_TRACE
+	if (debug_trace)
+	{
+		int written = snprintf(ret+total, len-total, "-v ");
+		total += written;
+	}
+#else
+#if DEBUG_LEVEL
+	if (debug_trace)
+	{
+		int i;
+		for (i=0; i<debug_trace; i++) {
+			int written = snprintf(ret+total, len-total, "-v ");
+			total += written;
+		}
+	}
+#endif
+#endif
 
 #if DROPBEAR_CLI_PUBKEY_AUTH
 	for (iter = cli_opts.privkeys->first; iter; iter = iter->next)

--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -96,6 +96,10 @@ static void printhelp() {
 					"-V    Version\n"
 #if DEBUG_TRACE
 					"-v    verbose (compiled with DEBUG_TRACE)\n"
+#else
+#if DEBUG_LEVEL
+					"-v    verbose level (repeat to be more verbose)\n"
+#endif
 #endif
 					,DROPBEAR_VERSION, cli_opts.progname,
 #if DROPBEAR_CLI_PUBKEY_AUTH
@@ -295,9 +299,9 @@ void cli_getopts(int argc, char ** argv) {
 					next = &opts.mac_list;
 					break;
 #endif
-#if DEBUG_TRACE
+#if DEBUG_LEVEL
 				case 'v':
-					debug_trace = 1;
+					debug_trace++;
 					break;
 #endif
 				case 'F':

--- a/cli-session.c
+++ b/cli-session.c
@@ -102,7 +102,7 @@ void cli_connected(int result, int sock, void* userdata, const char *errstring)
 		dropbear_exit("Connect failed: %s", errstring);
 	}
 	myses->sock_in = myses->sock_out = sock;
-	TRACE(("cli_connected"))
+	TRACELEVEL((1,"cli_connected"))
 	ses.socket_prio = DROPBEAR_PRIO_NORMAL;
 	/* switches to lowdelay */
 	update_channel_prio();

--- a/common-algo.c
+++ b/common-algo.c
@@ -463,7 +463,7 @@ algo_type * buf_match_algo(buffer* buf, algo_type localalgos[],
 
 	/* get the comma-separated list from the buffer ie "algo1,algo2,algo3" */
 	algolist = buf_getstring(buf, &len);
-	TRACE(("buf_match_algo: %s", algolist))
+	TRACELEVEL((3,"buf_match_algo: %s", algolist))
 	remotecount = MAX_PROPOSED_ALGO;
 	get_algolist(algolist, len, remotenames, &remotecount);
 

--- a/common-kex.c
+++ b/common-kex.c
@@ -869,7 +869,7 @@ static void read_kex_algos() {
 		goto error;
 	}
 	TRACE(("kexguess2 %d", kexguess2))
-	TRACE(("kex algo %s", algo->name))
+	TRACELEVEL((2,"kex algo %s", algo->name))
 	ses.newkeys->algo_kex = algo->data;
 
 	/* server_host_key_algorithms */
@@ -879,6 +879,8 @@ static void read_kex_algos() {
 		erralgo = "hostkey";
 		goto error;
 	}
+	TRACELEVEL((2,"hostkey algo %s", algo->name))
+	TRACE(("kex algo %s", algo->name))
 	TRACE(("signature algo %s", algo->name))
 	ses.newkeys->algo_signature = algo->val;
 	ses.newkeys->algo_hostkey = signkey_type_from_signature(ses.newkeys->algo_signature);
@@ -889,7 +891,8 @@ static void read_kex_algos() {
 		erralgo = "enc c->s";
 		goto error;
 	}
-	TRACE(("enc c2s is  %s", c2s_cipher_algo->name))
+	//TRACE(("enc c2s is  %s", c2s_cipher_algo->name))
+	TRACELEVEL((2,"enc  c2s is %s", c2s_cipher_algo->name))
 
 	/* encryption_algorithms_server_to_client */
 	s2c_cipher_algo = buf_match_algo(ses.payload, sshciphers, 0, NULL);
@@ -897,7 +900,8 @@ static void read_kex_algos() {
 		erralgo = "enc s->c";
 		goto error;
 	}
-	TRACE(("enc s2c is  %s", s2c_cipher_algo->name))
+	//TRACE(("enc s2c is  %s", s2c_cipher_algo->name))
+	TRACELEVEL((2,"enc  s2c is %s", s2c_cipher_algo->name))
 
 	/* mac_algorithms_client_to_server */
 	c2s_hash_algo = buf_match_algo(ses.payload, sshhashes, 0, NULL);
@@ -910,7 +914,8 @@ static void read_kex_algos() {
 		erralgo = "mac c->s";
 		goto error;
 	}
-	TRACE(("hash c2s is  %s", c2s_hash_algo ? c2s_hash_algo->name : "<implicit>"))
+	//TRACE(("hash c2s is  %s", c2s_hash_algo ? c2s_hash_algo->name : "<implicit>"))
+	TRACELEVEL((2,"hmac c2s is %s", c2s_hash_algo ? c2s_hash_algo->name : "<implicit>"))
 
 	/* mac_algorithms_server_to_client */
 	s2c_hash_algo = buf_match_algo(ses.payload, sshhashes, 0, NULL);
@@ -923,7 +928,8 @@ static void read_kex_algos() {
 		erralgo = "mac s->c";
 		goto error;
 	}
-	TRACE(("hash s2c is  %s", s2c_hash_algo ? s2c_hash_algo->name : "<implicit>"))
+	//TRACE(("hash s2c is  %s", s2c_hash_algo ? s2c_hash_algo->name : "<implicit>"))
+	TRACELEVEL((2,"hmac s2c is %s", s2c_hash_algo ? s2c_hash_algo->name : "<implicit>"))
 
 	/* compression_algorithms_client_to_server */
 	c2s_comp_algo = buf_match_algo(ses.payload, ses.compress_algos, 0, NULL);
@@ -931,7 +937,8 @@ static void read_kex_algos() {
 		erralgo = "comp c->s";
 		goto error;
 	}
-	TRACE(("hash c2s is  %s", c2s_comp_algo->name))
+	//TRACE(("hash c2s is  %s", c2s_comp_algo->name))
+	TRACELEVEL((2,"comp c2s is %s", c2s_comp_algo->name))
 
 	/* compression_algorithms_server_to_client */
 	s2c_comp_algo = buf_match_algo(ses.payload, ses.compress_algos, 0, NULL);
@@ -939,7 +946,8 @@ static void read_kex_algos() {
 		erralgo = "comp s->c";
 		goto error;
 	}
-	TRACE(("hash s2c is  %s", s2c_comp_algo->name))
+	//TRACE(("hash s2c is  %s", s2c_comp_algo->name))
+	TRACELEVEL((2,"comp s2c is %s", s2c_comp_algo->name))
 
 	/* languages_client_to_server */
 	buf_eatstring(ses.payload);

--- a/common-session.c
+++ b/common-session.c
@@ -404,7 +404,7 @@ static void read_session_identification() {
 		dropbear_exit("Incompatible remote version '%s'", ses.remoteident);
 	}
 
-	TRACE(("remoteident: %s", ses.remoteident))
+	TRACELEVEL((1,"remoteident: %s", ses.remoteident))
 
 }
 

--- a/dbutil.c
+++ b/dbutil.c
@@ -79,7 +79,7 @@ void (*_dropbear_exit)(int exitcode, const char* format, va_list param) ATTRIB_N
 void (*_dropbear_log)(int priority, const char* format, va_list param)
 						= generic_dropbear_log;
 
-#if DEBUG_TRACE
+#if DEBUG_LEVEL
 int debug_trace = 0;
 #endif
 
@@ -155,7 +155,7 @@ void dropbear_log(int priority, const char* format, ...) {
 }
 
 
-#if DEBUG_TRACE
+#if DEBUG_LEVEL
 
 static double debug_start_time = -1;
 
@@ -185,6 +185,22 @@ static double time_since_start()
 	return nowf - debug_start_time;
 }
 
+void dropbear_tracelevel(int level,const char* format, ...) {
+	va_list param;
+
+	if (level > debug_trace) {
+		return;
+	}
+
+	va_start(param, format);
+	fprintf(stderr, "TRACE  (%d) %f: ", getpid(), time_since_start());
+	vfprintf(stderr, format, param);
+	fprintf(stderr, "\n");
+	va_end(param);
+}
+#endif
+
+#if DEBUG_TRACE
 void dropbear_trace(const char* format, ...) {
 	va_list param;
 

--- a/dbutil.h
+++ b/dbutil.h
@@ -55,6 +55,12 @@ void debug_start_net(void);
 extern int debug_trace;
 #endif
 
+#if DEBUG_LEVEL
+void dropbear_tracelevel(int level,const char* format, ...) ATTRIB_PRINTF(2,3);
+void debug_start_net(void);
+extern int debug_trace;
+#endif
+
 char * stripcontrol(const char * text);
 
 int spawn_command(void(*exec_fn)(const void *user_data), const void *exec_data,

--- a/debug.h
+++ b/debug.h
@@ -58,6 +58,22 @@ extern int debug_trace;
 #define TRACE2(X)
 #endif /*DEBUG_TRACE*/
 
+/* Make sure DEBUG_LEVEL is defined
+ * if not take over value from DEBUG_TRACE */
+#ifndef DEBUG_LEVEL
+#if DEBUG_TRACE
+#define DEBUG_LEVEL 1
+#else
+#define DEBUG_LEVEL 0
+#endif
+#endif /*DEBUG_LEVEL*/
+
+#if DEBUG_LEVEL
+#define TRACELEVEL(X) dropbear_tracelevel X;
+#else
+#define TRACELEVEL(X)
+#endif
+
 /* To debug with GDB it is easier to run with no forking of child processes.
    You will need to pass "-F" as well. */
 #ifndef DEBUG_NOFORK

--- a/default_options.h
+++ b/default_options.h
@@ -48,9 +48,12 @@ IMPORTANT: Some options will require "make clean" after changes */
  * This will add a reasonable amount to your executable size. */
 #define DEBUG_TRACE 0
 
-/* Include limited verbose debug output, the number of debug messages
- * are controlled by specifying 1 or more -v at runtime.
- * This will add approx 2 kB to your executable size. */
+/* Use DEBUG_LEVEL 1 for a minimal set of debug messages to dbclient.
+ * The number of debug messages are controlled by specifying 1 or more -v at runtime.
+ *   verboselevel 1 = connect info + remoteid + auth method information
+ *   verboselevel 2 = choosen kex algos
+ *   verboselevel 3 = available algos
+ * This will add approx 4 kB to your executable size. */
 #define DEBUG_LEVEL 0
 
 /* Set this if you want to use the DROPBEAR_SMALL_CODE option. This can save

--- a/default_options.h
+++ b/default_options.h
@@ -48,6 +48,11 @@ IMPORTANT: Some options will require "make clean" after changes */
  * This will add a reasonable amount to your executable size. */
 #define DEBUG_TRACE 0
 
+/* Include limited verbose debug output, the number of debug messages
+ * are controlled by specifying 1 or more -v at runtime.
+ * This will add approx 2 kB to your executable size. */
+#define DEBUG_LEVEL 0
+
 /* Set this if you want to use the DROPBEAR_SMALL_CODE option. This can save
  * several kB in binary size however will make the symmetrical ciphers and hashes
  * slower, perhaps by 50%. Recommended for small systems that aren't doing


### PR DESCRIPTION
With DEBUG_TRACE you get none or all debug messages which is fine when doing in depth analysis.
With the new DEBUG_LEVEL you can specify a number of -v options to increase the verboseness of the debug messages.
To expand the number of messages just change in the code:  TRACE(("some message"))  to  TRACELEVEL((1,"some message"))
As an example I added some minimal dbclient tracelevels to debug connection problems.
 