### PR TITLE
Pubkeyinfo

### DIFF
--- a/auth.h
+++ b/auth.h
@@ -125,6 +125,7 @@ struct AuthState {
 	char *pw_passwd;
 #if DROPBEAR_SVR_PUBKEY_OPTIONS_BUILT
 	struct PubKeyOptions* pubkey_options;
+	char *pubkey_info;
 #endif
 };
 

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -356,6 +356,11 @@ static int checkpubkey_line(buffer* line, int line_num, const char* filename,
 
 	ret = cmp_base64_key(keyblob, keybloblen, (const unsigned char *) algo, algolen, line, NULL);
 
+	/* free pubkey_info if it is filled */
+	if (ses.authstate.pubkey_info) {
+		m_free(ses.authstate.pubkey_info);
+		ses.authstate.pubkey_info = NULL;
+	}
 	if (ret == DROPBEAR_SUCCESS) {
 		if (options_buf) {
 			ret = svr_add_pubkey_options(options_buf, line_num, filename);
@@ -364,11 +369,9 @@ static int checkpubkey_line(buffer* line, int line_num, const char* filename,
 		if (infolen) {
 			ses.authstate.pubkey_info = m_malloc(infolen + 1);
 			if (ses.authstate.pubkey_info) {
-				strncpy(ses.authstate.pubkey_info, &line->data[infopos], infolen);
+		                strncpy(ses.authstate.pubkey_info,(const char *) buf_getptr(line, infopos), infolen);
 				ses.authstate.pubkey_info[infolen]='\0';
 			}
-		} else {
-			ses.authstate.pubkey_info = NULL;
 		}
 	}
 

--- a/svr-authpubkeyoptions.c
+++ b/svr-authpubkeyoptions.c
@@ -115,6 +115,9 @@ void svr_pubkey_options_cleanup() {
 		}
 		m_free(ses.authstate.pubkey_options);
 	}
+	if (ses.authstate.pubkey_info) {
+		m_free(ses.authstate.pubkey_info);
+	}
 }
 
 /* helper for svr_add_pubkey_options. returns DROPBEAR_SUCCESS if the option is matched,

--- a/svr-chansession.c
+++ b/svr-chansession.c
@@ -1030,6 +1030,9 @@ static void execchild(const void *user_data) {
 	if (chansess->original_command) {
 		addnewvar("SSH_ORIGINAL_COMMAND", chansess->original_command);
 	}
+        if (ses.authstate.pubkey_info != NULL) {
+                addnewvar("SSH_PUBKEYINFO", ses.authstate.pubkey_info);
+        }
 
 	/* change directory */
 	if (chdir(ses.authstate.pw_dir) < 0) {


### PR DESCRIPTION
This allows you to get the pubkey info in environment var SSH_PUBKEYINFO when a ssh key is used to gain access.
So for instance:
ssh_rsa AAAAB3Nz....DI0XQ== hans1_key
ssh_rsa AAAAB3Nz....XF7DF== appl1_key
After getting access with the second key, you get in SSH_PUBKEYINFO="appl1_key"
Very handy to recognize the remote appl/user when performing automatic actions.
