### PR TITLE
Two-factor authentication support (pubkey and password)

### DIFF
--- a/dropbear.8
+++ b/dropbear.8
@@ -53,6 +53,10 @@ Disable password logins.
 .B \-g
 Disable password logins for root.
 .TP
+.B \-t
+Enable two-factor authentication. Both password login and public key authentication are
+required. Should not be used with the '-s' option.
+.TP
 .B \-j
 Disable local port forwarding.
 .TP

--- a/runopts.h
+++ b/runopts.h
@@ -105,6 +105,7 @@ typedef struct svr_runopts {
 	int noauthpass;
 	int norootpass;
 	int allowblankpass;
+	int multiauthmethod;
 	unsigned int maxauthtries;
 
 #if DROPBEAR_SVR_REMOTETCPFWD

--- a/svr-authpam.c
+++ b/svr-authpam.c
@@ -278,12 +278,22 @@ void svr_auth_pam(int valid_user) {
 		goto cleanup;
 	}
 
-	/* successful authentication */
-	dropbear_log(LOG_NOTICE, "PAM password auth succeeded for '%s' from %s",
-			ses.authstate.pw_name,
-			svr_ses.addrstring);
-	send_msg_userauth_success();
-
+	if (svr_opts.multiauthmethod && (ses.authstate.authtypes & ~AUTH_TYPE_PASSWORD)) {
+			/* successful PAM password authentication, but extra auth required */
+			dropbear_log(LOG_NOTICE,
+					"PAM password auth auth succeeded for '%s' from %s, extra auth required",
+					ses.authstate.pw_name,
+					svr_ses.addrstring);
+			ses.authstate.authtypes &= ~AUTH_TYPE_PASSWORD;
+			send_msg_userauth_failure(1, 0);  /* Send partial success */
+		} else {
+			/* successful authentication */
+			dropbear_log(LOG_NOTICE, "PAM password auth succeeded for '%s' from %s",
+				ses.authstate.pw_name,
+				svr_ses.addrstring);
+			send_msg_userauth_success();
+		}
+		
 cleanup:
 	if (password != NULL) {
 		m_burn(password, passwordlen);

--- a/svr-authpam.c
+++ b/svr-authpam.c
@@ -30,6 +30,7 @@
 #include "buffer.h"
 #include "dbutil.h"
 #include "auth.h"
+#include "runopts.h"
 
 #if DROPBEAR_SVR_PAM_AUTH
 

--- a/svr-authpam.c
+++ b/svr-authpam.c
@@ -282,10 +282,10 @@ void svr_auth_pam(int valid_user) {
 	if (svr_opts.multiauthmethod && (ses.authstate.authtypes & ~AUTH_TYPE_PASSWORD)) {
 			/* successful PAM password authentication, but extra auth required */
 			dropbear_log(LOG_NOTICE,
-					"PAM password auth auth succeeded for '%s' from %s, extra auth required",
+					"PAM password auth succeeded for '%s' from %s, extra auth required",
 					ses.authstate.pw_name,
 					svr_ses.addrstring);
-			ses.authstate.authtypes &= ~AUTH_TYPE_PASSWORD;
+			ses.authstate.authtypes &= ~AUTH_TYPE_PASSWORD; /* PAM password auth ok, delete the method flag */
 			send_msg_userauth_failure(1, 0);  /* Send partial success */
 		} else {
 			/* successful authentication */

--- a/svr-authpasswd.c
+++ b/svr-authpasswd.c
@@ -112,7 +112,7 @@ void svr_auth_password(int valid_user) {
 					"Password auth succeeded for '%s' from %s, extra auth required",
 					ses.authstate.pw_name,
 					svr_ses.addrstring);
-			ses.authstate.authtypes &= ~AUTH_TYPE_PASSWORD;
+			ses.authstate.authtypes &= ~AUTH_TYPE_PASSWORD; /* password auth ok, delete the method flag */
 			send_msg_userauth_failure(1, 0);  /* Send partial success */
 		} else {
 			/* successful authentication */

--- a/svr-authpasswd.c
+++ b/svr-authpasswd.c
@@ -106,12 +106,22 @@ void svr_auth_password(int valid_user) {
 	}
 
 	if (constant_time_strcmp(testcrypt, passwdcrypt) == 0) {
-		/* successful authentication */
-		dropbear_log(LOG_NOTICE, 
-				"Password auth succeeded for '%s' from %s",
-				ses.authstate.pw_name,
-				svr_ses.addrstring);
-		send_msg_userauth_success();
+		if (svr_opts.multiauthmethod && (ses.authstate.authtypes & ~AUTH_TYPE_PASSWORD)) {
+			/* successful password authentication, but extra auth required */
+			dropbear_log(LOG_NOTICE,
+					"Password auth succeeded for '%s' from %s, extra auth required",
+					ses.authstate.pw_name,
+					svr_ses.addrstring);
+			ses.authstate.authtypes &= ~AUTH_TYPE_PASSWORD;
+			send_msg_userauth_failure(1, 0);  /* Send partial success */
+		} else {
+			/* successful authentication */
+			dropbear_log(LOG_NOTICE, 
+					"Password auth succeeded for '%s' from %s",
+					ses.authstate.pw_name,
+					svr_ses.addrstring);
+			send_msg_userauth_success();
+		}
 	} else {
 		dropbear_log(LOG_WARNING,
 				"Bad password attempt for '%s' from %s",

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -203,6 +203,7 @@ void svr_auth_pubkey(int valid_user) {
 	fp = sign_key_fingerprint(keyblob, keybloblen);
 	if (buf_verify(ses.payload, key, sigtype, signbuf) == DROPBEAR_SUCCESS) {
 		if (svr_opts.multiauthmethod && (ses.authstate.authtypes & ~AUTH_TYPE_PUBKEY)) {
+			/* successful pubkey authentication, but extra auth required */
 			dropbear_log(LOG_NOTICE,
 					"Pubkey auth succeeded for '%s' with %s key %s from %s, extra auth required",
 					ses.authstate.pw_name,
@@ -211,6 +212,7 @@ void svr_auth_pubkey(int valid_user) {
 			ses.authstate.authtypes &= ~AUTH_TYPE_PUBKEY; /* pubkey auth ok, delete the method flag */
 			send_msg_userauth_failure(1, 0); /* Send partial success */
 		} else {
+			/* successful authentication */
 			dropbear_log(LOG_NOTICE,
 					"Pubkey auth succeeded for '%s' with %s key %s from %s",
 					ses.authstate.pw_name,

--- a/svr-runopts.c
+++ b/svr-runopts.c
@@ -81,6 +81,7 @@ static void printhelp(const char * progname) {
 					"-s		Disable password logins\n"
 					"-g		Disable password logins for root\n"
 					"-B		Allow blank password logins\n"
+					"-t		Enable two-factor authentication (both password and public key required)\n"
 #endif
 					"-T		Maximum authentication tries (default %d)\n"
 #if DROPBEAR_SVR_LOCALTCPFWD
@@ -158,6 +159,7 @@ void svr_getopts(int argc, char ** argv) {
 	svr_opts.noauthpass = 0;
 	svr_opts.norootpass = 0;
 	svr_opts.allowblankpass = 0;
+	svr_opts.multiauthmethod = 0;
 	svr_opts.maxauthtries = MAX_AUTH_TRIES;
 	svr_opts.inetdmode = 0;
 	svr_opts.portcount = 0;
@@ -294,6 +296,9 @@ void svr_getopts(int argc, char ** argv) {
 					break;
 				case 'B':
 					svr_opts.allowblankpass = 1;
+					break;
+				case 't':
+					svr_opts.multiauthmethod = 1;
 					break;
 #endif
 				case 'h':


### PR DESCRIPTION
This patch introduces two-factor authentication to require both password and pubkey authentication.
The two-factor authentication can be enabled with "-t" 

Background: We are using ssh in an environment where the security policy mandates multi-method authentication for SSH (both password and pubkey). Dropbear does currently not support this but this is defined in the RFC and supported by other mainstream SSH servers. Unfortunately the security policy cannot be changed.
The patch is kept very small and code flow is not changed when the -t option is not used to avoid any regressions. Only 1 new variable is introduced to keep track of the config setting. The existing variable `ses.authstate.authtypes` is  used to keep track of the successful authentications and a "partial success" message as defined in the RFC4252 is sent after one of the auth methods has successfully completed. 
The patch was validated with different ssh clients (dbclient, openssh, putty).