### PR TITLE
Implement no-touch-required and verify-requred for authorized_keys file

### DIFF
--- a/auth.h
+++ b/auth.h
@@ -139,6 +139,10 @@ struct PubKeyOptions {
 	int no_pty_flag;
 	/* "command=" option. */
 	char * forced_command;
+#if DROPBEAR_SK_ECDSA || DROPBEAR_SK_ED25519
+	int no_touch_required_flag;
+	int verify_required_flag;
+#endif
 };
 #endif
 

--- a/signkey.c
+++ b/signkey.c
@@ -688,7 +688,7 @@ int buf_verify(buffer * buf, sign_key *key, enum signature_type expect_sigtype, 
 	if (keytype == DROPBEAR_SIGNKEY_SK_ECDSA_NISTP256) {
 		ecc_key **eck = (ecc_key**)signkey_key_ptr(key, keytype);
 		if (eck && *eck) {
-			return buf_sk_ecdsa_verify(buf, *eck, data_buf, key->sk_app, key->sk_applen);
+			return buf_sk_ecdsa_verify(buf, *eck, data_buf, key->sk_app, key->sk_applen, key->sk_flags_mask);
 		}
 	}
 #endif
@@ -696,7 +696,7 @@ int buf_verify(buffer * buf, sign_key *key, enum signature_type expect_sigtype, 
 	if (keytype == DROPBEAR_SIGNKEY_SK_ED25519) {
 		dropbear_ed25519_key **eck = (dropbear_ed25519_key**)signkey_key_ptr(key, keytype);
 		if (eck && *eck) {
-			return buf_sk_ed25519_verify(buf, *eck, data_buf, key->sk_app, key->sk_applen);
+			return buf_sk_ed25519_verify(buf, *eck, data_buf, key->sk_app, key->sk_applen, key->sk_flags_mask);
 		}
 	}
 #endif

--- a/signkey.h
+++ b/signkey.h
@@ -127,6 +127,7 @@ struct SIGN_key {
 	/* application ID for U2F/FIDO key types, a malloced string */
 	char * sk_app;
 	unsigned int sk_applen;
+	unsigned char sk_flags_mask;
 #endif
 };
 

--- a/sk-ecdsa.h
+++ b/sk-ecdsa.h
@@ -8,7 +8,9 @@
 #include "buffer.h"
 #include "signkey.h"
 
-int buf_sk_ecdsa_verify(buffer *buf, const ecc_key *key, const buffer *data_buf, const char* app, unsigned int applen);
+int buf_sk_ecdsa_verify(buffer *buf, const ecc_key *key, const buffer *data_buf,
+			const char* app, unsigned int applen,
+			unsigned char sk_flags_mask);
 
 #endif
 

--- a/sk-ed25519.c
+++ b/sk-ed25519.c
@@ -8,7 +8,9 @@
 #include "ed25519.h"
 #include "ssh.h"
 
-int buf_sk_ed25519_verify(buffer *buf, const dropbear_ed25519_key *key, const buffer *data_buf, const char* app, unsigned int applen) {
+int buf_sk_ed25519_verify(buffer *buf, const dropbear_ed25519_key *key, const buffer *data_buf,
+			const char* app, unsigned int applen,
+			unsigned char sk_flags_mask) {
 
 	int ret = DROPBEAR_FAILURE;
 	unsigned char *s;
@@ -52,10 +54,15 @@ int buf_sk_ed25519_verify(buffer *buf, const dropbear_ed25519_key *key, const bu
 		ret = DROPBEAR_SUCCESS;
 	}
 
-	/* TODO: allow "no-touch-required" or "verify-required" authorized_keys options */
-	if (!(flags & SSH_SK_USER_PRESENCE_REQD)) {
+	if (~flags & sk_flags_mask & SSH_SK_USER_PRESENCE_REQD) {
 		if (ret == DROPBEAR_SUCCESS) {
 			dropbear_log(LOG_WARNING, "Rejecting, user-presence not set");
+		}
+		ret = DROPBEAR_FAILURE;
+	}
+	if (~flags & sk_flags_mask & SSH_SK_USER_VERIFICATION_REQD) {
+		if (ret == DROPBEAR_SUCCESS) {
+			dropbear_log(LOG_WARNING, "Rejecting, user-verification not set");
 		}
 		ret = DROPBEAR_FAILURE;
 	}

--- a/sk-ed25519.h
+++ b/sk-ed25519.h
@@ -8,7 +8,9 @@
 #include "buffer.h"
 #include "ed25519.h"
 
-int buf_sk_ed25519_verify(buffer *buf, const dropbear_ed25519_key *key, const buffer *data_buf, const char* app, unsigned int applen);
+int buf_sk_ed25519_verify(buffer *buf, const dropbear_ed25519_key *key, const buffer *data_buf,
+			const char* app, unsigned int applen,
+			unsigned char sk_flags_mask);
 
 #endif
 

--- a/svr-authpubkey.c
+++ b/svr-authpubkey.c
@@ -182,6 +182,16 @@ void svr_auth_pubkey(int valid_user) {
 		goto out;
 	}
 
+#if DROPBEAR_SK_ECDSA || DROPBEAR_SK_ED25519
+	key->sk_flags_mask = SSH_SK_USER_PRESENCE_REQD;
+	if (ses.authstate.pubkey_options && ses.authstate.pubkey_options->no_touch_required_flag) {
+		key->sk_flags_mask &= ~SSH_SK_USER_PRESENCE_REQD;
+	}
+	if (ses.authstate.pubkey_options && ses.authstate.pubkey_options->verify_required_flag) {
+		key->sk_flags_mask |= SSH_SK_USER_VERIFICATION_REQD;
+	}
+#endif
+
 	/* create the data which has been signed - this a string containing
 	 * session_id, concatenated with the payload packet up to the signature */
 	assert(ses.payload_beginning <= ses.payload->pos);

--- a/svr-authpubkeyoptions.c
+++ b/svr-authpubkeyoptions.c
@@ -205,6 +205,20 @@ int svr_add_pubkey_options(buffer *options_buf, int line_num, const char* filena
 			dropbear_log(LOG_WARNING, "Badly formatted command= authorized_keys option");
 			goto bad_option;
 		}
+		if (match_option(options_buf, "no-touch-required") == DROPBEAR_SUCCESS) {
+#if DROPBEAR_SK_ECDSA || DROPBEAR_SK_ED25519
+			dropbear_log(LOG_WARNING, "No user presence check required for U2F/FIDO key.");
+			ses.authstate.pubkey_options->no_touch_required_flag = 1;
+#endif
+			goto next_option;
+		}
+		if (match_option(options_buf, "verify-required") == DROPBEAR_SUCCESS) {
+#if DROPBEAR_SK_ECDSA || DROPBEAR_SK_ED25519
+			dropbear_log(LOG_WARNING, "User verification required for U2F/FIDO key.");
+			ses.authstate.pubkey_options->verify_required_flag = 1;
+#endif
+			goto next_option;
+		}
 
 next_option:
 		/*


### PR DESCRIPTION
This PR add support for no-touch-required and verify-required options for ecdsa-sk and ed25519-sk keys in authorized_keys file

Fixes #171