### PR TITLE
Make default compatibility getusershell() paths configurable

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -232,7 +232,7 @@ void setusershell() {
 
 static char **initshells() {
 	/* don't touch this list. */
-	static const char *okshells[] = { "/bin/sh", "/bin/csh", NULL };
+	static const char *okshells[] = { DROPBEAR_PATH_BSHELL, DROPBEAR_PATH_CSHELL, NULL };
 	register char **sp, *cp;
 	register FILE *fp;
 	struct stat statb;

--- a/compat.h
+++ b/compat.h
@@ -47,6 +47,21 @@ char *basename(const char* path);
 char *getusershell(void);
 void setusershell(void);
 void endusershell(void);
+
+#ifndef DROPBEAR_PATH_BSHELL
+#ifdef _PATH_BSHELL
+#define DROPBEAR_PATH_BSHELL _PATH_BSHELL
+#else
+#define DROPBEAR_PATH_BSHELL "/bin/sh"
+#endif
+#endif
+#ifndef DROPBEAR_PATH_CSHELL
+#ifdef _PATH_CSHELL
+#define DROPBEAR_PATH_CSHELL _PATH_CSHELL
+#else
+#define DROPBEAR_PATH_CSHELL "/bin/csh"
+#endif
+#endif
 #endif
 
 #ifndef DROPBEAR_PATH_DEVNULL


### PR DESCRIPTION
Allow overriding the default shell paths returned by the compatibility `getusershell` function with new macros `DROPBEAR_PATH_BSHELL` and `DROPBEAR_PATH_CSHELL`.  Default these to the values of `_PATH_BSHELL` and
`_PATH_CSHELL` if they are defined (generally in paths.h) or fall back to the original sane values if neither is set.

This fixes server login under Android (without having to add `/etc/shells`) and should provide flexibility for other systems missing `getusershell` with odd file system layouts.  (While writing this up I realised this was one of the problems encountered in #176 but hadn't seen that issue previously).

I left the slightly ominous `/* don't touch this list. */` comment in-place above the default list of shells as I wasn't quite sure of the significance, unless I'm mistaken the repository history doesn't go back far enough to shed light on it..?

Also considered moving `DROPBEAR_PATH_BSHELL` out of compat.h and using the value in [common-session.c](https://github.com/mkj/dropbear/blob/17e02fe614065025a11d544ec17264f209272f11/common-session.c#L614) but decided to err on the side of caution.  Happy to add that to this PR if you'd prefer though.