### PR TITLE
Fix utx var typo

### DIFF
--- a/loginrec.c
+++ b/loginrec.c
@@ -829,7 +829,7 @@ utmpx_perform_login(struct logininfo *li)
 		return 0;
 	}
 # else
-	if (!utmpx_write_direct(li, &ut)) {
+	if (!utmpx_write_direct(li, &utx)) {
 		dropbear_log(LOG_WARNING, "utmpx_perform_login: utmp_write_direct() failed");
 		return 0;
 	}


### PR DESCRIPTION
Fixed a typo error which arises when `UTMPX_USE_LIBRARY` is not defined