### PR TITLE
Dbclient: Flush stdin after fingerprint confirmation

### DIFF
--- a/cli-kex.c
+++ b/cli-kex.c
@@ -229,7 +229,7 @@ static void ask_to_confirm(const unsigned char* keyblob, unsigned int keybloblen
 		fclose(tty);
 	} else {
 		response = getc(stdin);
-		// flush stdin buffer
+		/* flush stdin buffer */
 		while ((getchar()) != '\n');
 	}
 

--- a/cli-kex.c
+++ b/cli-kex.c
@@ -229,6 +229,8 @@ static void ask_to_confirm(const unsigned char* keyblob, unsigned int keybloblen
 		fclose(tty);
 	} else {
 		response = getc(stdin);
+		// flush stdin buffer
+		while ((getchar()) != '\n');
 	}
 
 	if (response == 'y') {


### PR DESCRIPTION
When asking if continue connecting even if the fingerprint is not in the trusted hosts file, dbclient reads the first char from stdin but doesn't flush the text after until the newline. This causes the following prompt to fail automatically (for example the password prompt)