### PR TITLE
Add function to port forward to local stream to support VSCode remote ssh target.

### DIFF
--- a/channel.h
+++ b/channel.h
@@ -101,7 +101,7 @@ struct ChanType {
 	void (*cleanup)(const struct Channel*);
 };
 
-/* Callback for connect_remote. errstring may be NULL if result == DROPBEAR_SUCCESS */
+/* Callback for connect_remote/connect_streamlocal. errstring may be NULL if result == DROPBEAR_SUCCESS */
 void channel_connect_done(int result, int sock, void* user_data, const char* errstring);
 
 void chaninitialise(const struct ChanType *chantypes[]);

--- a/default_options.h
+++ b/default_options.h
@@ -70,6 +70,7 @@ IMPORTANT: Some options will require "make clean" after changes */
 
 #define DROPBEAR_SVR_LOCALTCPFWD 1
 #define DROPBEAR_SVR_REMOTETCPFWD 1
+#define DROPBEAR_SVR_LOCALSTREAMFWD 1
 
 /* Enable Authentication Agent Forwarding */
 #define DROPBEAR_SVR_AGENTFWD 1

--- a/netio.c
+++ b/netio.c
@@ -274,7 +274,7 @@ struct dropbear_progress_connection *connect_streamlocal(const char* localpath,
 	sunaddr->sun_family = AF_UNIX;
 	strlcpy(sunaddr->sun_path, localpath, sizeof(sunaddr->sun_path));
 
-	// Copy to target iter.
+	/* Copy to target iter */ 
 	c->res_iter = c->res;
 
 	return c;

--- a/netio.c
+++ b/netio.c
@@ -262,7 +262,7 @@ struct dropbear_progress_connection *connect_streamlocal(const char* localpath,
 #endif
 
 	if (strlen(localpath) >= sizeof(sunaddr->sun_path)) {
-		c->errstring = m_strdup("Stream path too long")
+		c->errstring = m_strdup("Stream path too long");
 		TRACE(("%s: %s", localpath, strerror(ENAMETOOLONG)));
 		return c;
 	}

--- a/netio.c
+++ b/netio.c
@@ -263,7 +263,7 @@ struct dropbear_progress_connection *connect_streamlocal(const char* localpath,
 
 	if (strlen(localpath) >= sizeof(sunaddr->sun_path)) {
 		c->errstring = m_strdup("Stream path too long");
-		TRACE(("%s: %s", localpath, strerror(ENAMETOOLONG)));
+		TRACE(("localpath: %s is too long", localpath));
 		return c;
 	}
 

--- a/netio.c
+++ b/netio.c
@@ -28,7 +28,7 @@ struct dropbear_progress_connection {
 Does not close sockets */
 static void remove_connect(struct dropbear_progress_connection *c, m_list_elem *iter) {
 	if (c->res) {
-		// Only call freeaddrinfo if connection is not AF_UNIX.
+		/* Only call freeaddrinfo if connection is not AF_UNIX. */
 		if (c->res->ai_family != AF_UNIX) {
 			freeaddrinfo(c->res);
 		} else {
@@ -78,7 +78,9 @@ static void connect_try_next(struct dropbear_progress_connection *c) {
 			continue;
 		}
 
-		// According to the connect(2) manpage it should be testing EAGAIN rather than EINPROGRESS for unix sockets.
+		/* According to the connect(2) manpage it should be testing EAGAIN
+		 * rather than EINPROGRESS for unix sockets.
+		 */
 		retry_errno = r->ai_family == AF_UNIX ? EAGAIN : EINPROGRESS;
 
 		if (c->bind_address || c->bind_port) {

--- a/netio.c
+++ b/netio.c
@@ -245,7 +245,7 @@ struct dropbear_progress_connection *connect_streamlocal(const char* localpath,
 
 #if DROPBEAR_FUZZ
 	if (fuzz.fuzzing) {
-		c->errstring = m_strdup("fuzzing connect_remote always fails");
+		c->errstring = m_strdup("fuzzing connect_streamlocal always fails");
 		return c;
 	}
 #endif

--- a/netio.h
+++ b/netio.h
@@ -32,6 +32,11 @@ struct dropbear_progress_connection * connect_remote (const char* remotehost, co
 	connect_callback cb, void *cb_data, const char* bind_address, const char* bind_port,
 	enum dropbear_prio prio);
 
+/* Connect to local stream, always returns a progress connection, if it fails it will call the callback at a later point */
+struct dropbear_progress_connection * connect_streamlocal (const char* localpath,
+	connect_callback cb, void *cb_data,
+	enum dropbear_prio prio);
+
 /* Sets up for select() */
 void set_connect_fds(fd_set *writefd);
 /* Handles ready sockets after select() */

--- a/svr-session.c
+++ b/svr-session.c
@@ -76,6 +76,9 @@ static const struct ChanType *svr_chantypes[] = {
 #if DROPBEAR_SVR_LOCALTCPFWD
 	&svr_chan_tcpdirect,
 #endif
+#if DROPBEAR_SVR_LOCALSTREAMFWD
+	&svr_chan_streamlocal,
+#endif
 	NULL /* Null termination is mandatory. */
 };
 

--- a/svr-tcpfwd.c
+++ b/svr-tcpfwd.c
@@ -329,7 +329,6 @@ static int newstreamlocal(struct Channel * channel) {
 	char* desthost = NULL;
 	char* orighost = NULL;
 	unsigned int origport;
-	// char portstring[NI_MAXSERV];
 	unsigned int len;
 	int err = SSH_OPEN_ADMINISTRATIVELY_PROHIBITED;
 

--- a/tcpfwd.h
+++ b/tcpfwd.h
@@ -62,6 +62,8 @@ void recv_msg_global_request_remotetcp(void);
 
 extern const struct ChanType svr_chan_tcpdirect;
 
+extern const struct ChanType svr_chan_streamlocal;
+
 /* Client */
 void setup_localtcp(void);
 void setup_remotetcp(void);


### PR DESCRIPTION
VSCode remote ssh plugin need to create port forward between local port and remote unix socket, which is not yet support by current version of dropbear, this patch add a simple impl of port forwarding to local stream, only test on centos, debian x64, should work on any other linux variant. Any advice is welcome, thanks.