### PR TITLE
Per Client Config File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tags
 .pytest*
 *.pyc
 /test/venv
+.vscode/

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-See [INSTALL](INSTALL) for build instructions. 
+See [INSTALL](INSTALL) for build instructions.
 [SMALL](SMALL) has hints for building smaller binaries, also see comments
 in [default_options.h](default_options.h).
 
@@ -17,7 +17,7 @@ export CFLAGS="$CFLAGS -g"
 Set `#define DEBUG_TRACE 1` in localoptions.h to enable a `-v` option
 for dropbear and dbclient. That prints various details of the session. For
 development running `dropbear -F -E` is useful to run in the foreground. You
-can set `#define DEBUG_NOFORK 1` to make dropbear a one-shot server, easy to 
+can set `#define DEBUG_NOFORK 1` to make dropbear a one-shot server, easy to
 run under a debugger.
 
 ## Random sources
@@ -26,15 +26,15 @@ Most cryptography requires a good random entropy source, both to generate secret
 keys and in the course of a session. Dropbear uses the Linux kernel's
 `getrandom()` syscall to ensure that the system RNG has been initialised before
 using it. On some systems there is insufficient entropy gathered during early
-boot - generating hostkeys then will block for some amount of time. 
-Dropbear has a `-R` option to generate hostkeys upon the first connection 
+boot - generating hostkeys then will block for some amount of time.
+Dropbear has a `-R` option to generate hostkeys upon the first connection
 as required - that will allow the system more time to gather entropy.
 
 ## Algorithms
 
 Default algorithm lists are specified in [common-algo.c](common-algo.c).
 They are in priority order, the client's first matching choice is used
-(see rfc4253). 
+(see rfc4253).
 Dropbear client has `-c` and `-m` arguments to choose which are enabled at
 runtime (doesn't work for server as of June 2020).
 
@@ -43,11 +43,23 @@ see [default_options.h](default_options.h).
 
 ## Style
 
+In general please conform to the current style of the file you are editing.
+
 Source code is indented with tabs, width set to 4 (though width shouldn't
 matter much). Braces are on the same line as functions/loops/if - try
 to keep consistency with existing code.
 
 All `if` statements should have braces, no exceptions.
+
+Add a single space between flow control statements and their open parenthesis:
+```
+if (...
+for (...
+switch (...
+etc.
+```
+
+Use `snake_case` for variable and function names.
 
 Avoid using pointer arithmetic, instead the functions in
 [buffer.h](buffer.h) should be used.
@@ -67,15 +79,15 @@ Improvements can be sent upstream to the libtom project.
 
 ## Non-root user
 
-Dropbear server will run fine as a non-root user, allowing logins only for 
-that user. Password authentication probably won't work (can't read shadow 
+Dropbear server will run fine as a non-root user, allowing logins only for
+that user. Password authentication probably won't work (can't read shadow
 passwords). You will need to create hostkeys that are readable.
 
-## Connection setup 
+## Connection setup
 
-Dropbear implements first_kex_packet_follows to reduce 
-handshake latency (rfc 4253 7.1). Some less common implementations don't 
+Dropbear implements first_kex_packet_follows to reduce
+handshake latency (rfc 4253 7.1). Some less common implementations don't
 handle that, it can be a cause of problems connecting. Note also that
-Dropbear may send several ssh packets within a single TCP packet - it's just a 
+Dropbear may send several ssh packets within a single TCP packet - it's just a
 stream.
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -4,7 +4,13 @@
 
 See [INSTALL](INSTALL) for build instructions. 
 [SMALL](SMALL) has hints for building smaller binaries, also see comments
-in default_options.h.
+in [default_options.h](default_options.h).
+
+To be able to debug add `-g` compiler option to the `CFLAGS` environment
+variable. This will generate debug symbols.
+```
+export CFLAGS="$CFLAGS -g"
+```
 
 ## Debug printing
 

--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,8 @@ Basic Dropbear build instructions:
   are described in default_options.h, these will be overridden by
   anything set in localoptions.h
   localoptions.h should be located in the build directory if you are
-  building out of tree.
+  building out of tree. Note that the file is not tracked (.gitignore-d)
+  and you may need to create it.
 
 - Configure for your system:
   ./configure     (optionally with --disable-zlib or --disable-syslog,

--- a/Makefile.in
+++ b/Makefile.in
@@ -48,7 +48,7 @@ SVROBJS=svr-kex.o svr-auth.o sshpty.o \
 CLIOBJS=cli-main.o cli-auth.o cli-authpasswd.o cli-kex.o \
 		cli-session.o cli-runopts.o cli-chansession.o \
 		cli-authpubkey.o cli-tcpfwd.o cli-channel.o cli-authinteract.o \
-		cli-agentfwd.o 
+		cli-agentfwd.o cli-readconf.o
 
 CLISVROBJS=common-session.o packet.o common-algo.o common-kex.o \
 			common-channel.o common-chansession.o termcodes.o loginrec.o \

--- a/cli-readconf.c
+++ b/cli-readconf.c
@@ -1,0 +1,192 @@
+/*
+ * Dropbear - a SSH2 server
+ * 
+ * Copyright (c) 2023 TJ Kolev
+ * All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE. */
+
+#include "dbutil.h"
+#include "runopts.h"
+
+#if DROPBEAR_DEFAULT_USE_SSH_CONFIG
+
+#define TOKEN_CHARS " =\t\n"
+
+#if DROPBEAR_CLI_PUBKEY_AUTH
+extern void loadidentityfile(const char* filename, int warnfail);
+#endif
+
+typedef enum {
+	opInvalid = -1,
+	opHost,
+	opHostName,
+	opHostPort,
+	opLoginUser,
+	opIdentityFile,
+} CfgOption;
+
+static struct {
+	const char *name;
+	CfgOption option;
+} ConfigOptions[] =
+{
+	// start of config section
+	{ "host", opHost },
+
+	{ "hostname", opHostName },
+	{ "port", opHostPort },
+	{ "user", opLoginUser },
+	{ "identityfile", opIdentityFile },
+
+	// end loop condintion
+	{ NULL, opInvalid },
+};
+
+void read_config_file(char* filename, FILE* configFile, cli_runopts* options)
+{
+	DEBUG1(("Reading configuration data '%.200s'", filename));
+
+	char *line = NULL;
+	size_t linesize = 0;
+	int linenum = 0;
+
+	char* cfgKey;
+	char* cfgVal;
+	char* saveptr;
+
+	int inHostSection = 0;
+	while(-1 != getline(&line, &linesize, configFile))
+	{
+		/* Update line number counter. */
+		linenum++;
+
+		char* commentStart = strchr(line, '#');
+		if(NULL != commentStart)
+		{
+			*commentStart = '\0'; // drop the comments
+		}
+
+		cfgKey = strtok_r(line, TOKEN_CHARS, &saveptr);
+		if(NULL == cfgKey)
+		{
+			continue;
+		}
+
+		CfgOption cfgOpt = opInvalid;
+		for (int i = 0; ConfigOptions[i].name; i++)
+		{
+			if (0 == strcasecmp(cfgKey, ConfigOptions[i].name))
+			{
+				cfgOpt = ConfigOptions[i].option;
+				break;
+			}
+		}
+
+		if(opInvalid == cfgOpt)
+		{
+			dropbear_exit("Unhandled key %s at '%s':%d.", cfgKey, filename, linenum);
+		}
+
+		
+		cfgVal = strtok_r(NULL, TOKEN_CHARS, &saveptr);
+		if(NULL == cfgVal)
+		{
+			dropbear_exit("Missing value for key %s at '%s':%d.", cfgKey, filename, linenum);
+		}
+
+		if(inHostSection)
+		{
+			if(opHost == cfgOpt)
+			{
+				// Hit the next host section. Done reading config.
+				break;
+			}
+			switch(cfgOpt)
+			{
+				case opHostName:
+				{
+					// The host name is the alias given on the command line.
+					// Set the actual remote host specified in the config.
+					options->remotehost = strdup(cfgVal);
+					options->remotehostfixed = 1; // Subsequent command line parsing should leave it alone.
+					break;
+				}
+
+				case opHostPort:
+				{
+					options->remoteport = strdup(cfgVal);
+					break;
+				}
+
+				case opLoginUser:
+				{
+					options->username = strdup(cfgVal);
+					break;
+				}
+
+				case opIdentityFile:
+				{
+#if DROPBEAR_CLI_PUBKEY_AUTH
+					char* keyFilePath;
+					if(strncmp(cfgVal, "~/", 2) == 0)
+					{
+						keyFilePath = expand_homedir_path(cfgVal);
+					}
+					else if(cfgVal[0] != '/')
+					{
+						char* configDir = dirname(filename);
+						int pathLen = strlen(configDir) + strlen(cfgVal) + 10;
+						char cbuff[pathLen];
+						snprintf(cbuff, pathLen, "%s/%s", configDir, cfgVal);
+						keyFilePath = strdup(cbuff);
+					}
+					else
+					{
+						keyFilePath = strdup(cfgVal);
+					}
+					loadidentityfile(keyFilePath, 1);
+					free(keyFilePath);
+#else
+					dropbear_exit("This version of the code does not support identity file. %s at '%s':%d.", cfgKey, filename, linenum);
+#endif
+					break;
+				}
+
+				default:
+				{
+					dropbear_exit("Unsupported configuration option %s at '%s':%d.", cfgKey, filename, linenum);
+				}
+			}
+		}
+		else
+		{
+			if(opHost != cfgOpt || 0 != strcmp(cfgVal, options->remotehost))
+			{
+				// Not our host section
+				continue;
+			}
+			inHostSection = 1;
+		}
+	}
+
+	free(line);
+}
+
+#endif // DROPBEAR_DEFAULT_USE_SSH_CONFIG

--- a/cli-readconf.c
+++ b/cli-readconf.c
@@ -1,19 +1,19 @@
 /*
  * Dropbear - a SSH2 server
- * 
+ *
  * Copyright (c) 2023 TJ Kolev
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -47,7 +47,7 @@ static struct {
 	CfgOption option;
 } ConfigOptions[] =
 {
-	// start of config section
+	/* Start of config section. */
 	{ "host", opHost },
 
 	{ "hostname", opHostName },
@@ -55,7 +55,7 @@ static struct {
 	{ "user", opLoginUser },
 	{ "identityfile", opIdentityFile },
 
-	// end loop condintion
+	/* End loop condintion. */
 	{ NULL, opInvalid },
 };
 
@@ -80,7 +80,7 @@ void read_config_file(char* filename, FILE* configFile, cli_runopts* options)
 		char* commentStart = strchr(line, '#');
 		if(NULL != commentStart)
 		{
-			*commentStart = '\0'; // drop the comments
+			*commentStart = '\0'; /* Drop the comments. */
 		}
 
 		cfgKey = strtok_r(line, TOKEN_CHARS, &saveptr);
@@ -104,7 +104,7 @@ void read_config_file(char* filename, FILE* configFile, cli_runopts* options)
 			dropbear_exit("Unhandled key %s at '%s':%d.", cfgKey, filename, linenum);
 		}
 
-		
+
 		cfgVal = strtok_r(NULL, TOKEN_CHARS, &saveptr);
 		if(NULL == cfgVal)
 		{
@@ -115,17 +115,18 @@ void read_config_file(char* filename, FILE* configFile, cli_runopts* options)
 		{
 			if(opHost == cfgOpt)
 			{
-				// Hit the next host section. Done reading config.
+				/* Hit the next host section. Done reading config. */
 				break;
 			}
 			switch(cfgOpt)
 			{
 				case opHostName:
 				{
-					// The host name is the alias given on the command line.
-					// Set the actual remote host specified in the config.
+					/* The host name is the alias given on the command line.
+					 * Set the actual remote host specified in the config.
+					 */
 					options->remotehost = strdup(cfgVal);
-					options->remotehostfixed = 1; // Subsequent command line parsing should leave it alone.
+					options->remotehostfixed = 1; /* Subsequent command line parsing should leave it alone. */
 					break;
 				}
 
@@ -179,7 +180,7 @@ void read_config_file(char* filename, FILE* configFile, cli_runopts* options)
 		{
 			if(opHost != cfgOpt || 0 != strcmp(cfgVal, options->remotehost))
 			{
-				// Not our host section
+				/* Not our host section. */
 				continue;
 			}
 			inHostSection = 1;
@@ -189,4 +190,4 @@ void read_config_file(char* filename, FILE* configFile, cli_runopts* options)
 	free(line);
 }
 
-#endif // DROPBEAR_DEFAULT_USE_SSH_CONFIG
+#endif /* DROPBEAR_DEFAULT_USE_SSH_CONFIG */

--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -1,19 +1,19 @@
 /*
  * Dropbear - a SSH2 server
- * 
+ *
  * Copyright (c) 2002,2003 Matt Johnston
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -90,7 +90,7 @@ static void printhelp() {
 					"-z    disable QoS\n"
 #if DROPBEAR_CLI_NETCAT
 					"-B <endhost:endport> Netcat-alike forwarding\n"
-#endif				
+#endif
 #if DROPBEAR_CLI_PROXYCMD
 					"-J <proxy_program> Use program pipe rather than TCP connection\n"
 #endif
@@ -108,7 +108,7 @@ static void printhelp() {
 					DROPBEAR_DEFAULT_CLI_AUTHKEY,
 #endif
 					DEFAULT_RECV_WINDOW, DEFAULT_KEEPALIVE, DEFAULT_IDLE_TIMEOUT);
-					
+
 }
 
 void cli_getopts(int argc, char ** argv) {
@@ -403,7 +403,7 @@ void cli_getopts(int argc, char ** argv) {
 	apply_config_settings(host_arg);
 #endif
 
-	// Apply needed defaults if missing from command line or config file.
+	/* Apply needed defaults if missing from command line or config file. */
 	if (cli_opts.remoteport == NULL) {
 		cli_opts.remoteport = "22";
 	}
@@ -620,8 +620,8 @@ static void parse_multihop_hostname(const char* orighostarg, const char* argv0) 
 	 * for our multihop syntax, so we suture it back together.
 	 * This will break usernames that have both '@' and ',' in them,
 	 * though that should be fairly uncommon. */
-	if (cli_opts.username 
-			&& strchr(cli_opts.username, ',') 
+	if (cli_opts.username
+			&& strchr(cli_opts.username, ',')
 			&& strchr(cli_opts.username, '@')) {
 		unsigned int len = strlen(orighostarg) + strlen(cli_opts.username) + 2;
 		hostbuf = m_malloc(len);
@@ -674,7 +674,7 @@ static void parse_hostname(const char* orighostarg) {
 	char *port = NULL;
 
 	userhostarg = m_strdup(orighostarg);
-	
+
 	char* remotehost = strchr(userhostarg, '@');
 	if (remotehost == NULL) {
 		/* no username portion, the cli-auth.c code can figure the
@@ -709,9 +709,9 @@ static void parse_hostname(const char* orighostarg) {
 #if DROPBEAR_CLI_NETCAT
 static void add_netcat(const char* origstr) {
 	char *portstr = NULL;
-	
+
 	char * str = m_strdup(origstr);
-	
+
 	portstr = strchr(str, ':');
 	if (portstr == NULL) {
 		TRACE(("No netcat port"))
@@ -719,25 +719,25 @@ static void add_netcat(const char* origstr) {
 	}
 	*portstr = '\0';
 	portstr++;
-	
+
 	if (strchr(portstr, ':')) {
 		TRACE(("Multiple netcat colons"))
 		goto fail;
 	}
-	
+
 	if (m_str_to_uint(portstr, &cli_opts.netcat_port) == DROPBEAR_FAILURE) {
 		TRACE(("bad netcat port"))
 		goto fail;
 	}
-	
+
 	if (cli_opts.netcat_port > 65535) {
 		TRACE(("too large netcat port"))
 		goto fail;
 	}
-	
+
 	cli_opts.netcat_host = str;
 	return;
-	
+
 fail:
 	dropbear_exit("Bad netcat endpoint '%s'", origstr);
 }
@@ -745,7 +745,7 @@ fail:
 
 static void fill_own_user() {
 	uid_t uid;
-	struct passwd *pw = NULL; 
+	struct passwd *pw = NULL;
 
 	uid = getuid();
 
@@ -775,7 +775,7 @@ static void addforward(const char* origstr, m_list *fwdlist) {
 	TRACE(("enter addforward"))
 
 	/* We need to split the original argument up. This var
-	   is never free()d. */ 
+	   is never free()d. */
 	str = m_strdup(origstr);
 
 	part1 = str;
@@ -835,7 +835,7 @@ static void addforward(const char* origstr, m_list *fwdlist) {
 		TRACE(("listenport > 65535"))
 		goto badport;
 	}
-		
+
 	if (newfwd->connectport > 65535) {
 		TRACE(("connectport > 65535"))
 		goto badport;
@@ -954,7 +954,7 @@ void apply_config_settings(char* cli_host_arg)
 		}
 		else
 		{
-			parse_hostname(cli_host_arg); // Needed as key into the config
+			parse_hostname(cli_host_arg); /* Needed as key into the config. */
 			read_config_file(configPath, f, &cli_opts);
 			fclose(f);
 		}

--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -48,7 +48,7 @@ static void add_netcat(const char *str);
 #endif
 static void add_extendedopt(const char *str);
 
-#if DROPBEAR_DEFAULT_USE_SSH_CONFIG
+#if DROPBEAR_USE_SSH_CONFIG
 void apply_config_settings(char* cli_host_arg);
 #endif
 
@@ -399,7 +399,7 @@ void cli_getopts(int argc, char ** argv) {
 	}
 	TRACE(("host is: %s", host_arg))
 
-#if DROPBEAR_DEFAULT_USE_SSH_CONFIG
+#if DROPBEAR_USE_SSH_CONFIG
 	apply_config_settings(host_arg);
 #endif
 
@@ -701,8 +701,7 @@ static void parse_hostname(const char* orighostarg) {
 		dropbear_exit("Bad hostname.");
 	}
 
-	if(!cli_opts.remotehostfixed)
-	{
+	if (!cli_opts.remotehostfixed) {
 		cli_opts.remotehost = remotehost;
 	}
 }
@@ -941,25 +940,21 @@ static void add_extendedopt(const char* origstr) {
 	dropbear_log(LOG_WARNING, "Ignoring unknown configuration option '%s'", origstr);
 }
 
-#if DROPBEAR_DEFAULT_USE_SSH_CONFIG
-void apply_config_settings(char* cli_host_arg)
-{
-	char* isMultiHopHostTarget = strchr(cli_host_arg, ',');
-	if(!isMultiHopHostTarget)
-	{
-		char* configPath = expand_homedir_path(DROPBEAR_DEFAULT_SSH_CONFIG);
+#if DROPBEAR_USE_SSH_CONFIG
+void apply_config_settings(char* cli_host_arg) {
+	char* is_multi_hop_host_target = strchr(cli_host_arg, ',');
+	if (!is_multi_hop_host_target) {
+		char* config_path = expand_homedir_path(DROPBEAR_DEFAULT_SSH_CONFIG);
 		FILE* f;
-		if((f = fopen(configPath, "r")) == NULL)
-		{
-			DEBUG1(("Configuration file '%.200s' not found.", configPath));
+		if ((f = fopen(config_path, "r")) == NULL) {
+			DEBUG1(("Configuration file '%.200s' not found.", config_path));
 		}
-		else
-		{
+		else {
 			parse_hostname(cli_host_arg); /* Needed as key into the config. */
-			read_config_file(configPath, f, &cli_opts);
+			read_config_file(config_path, f, &cli_opts);
 			fclose(f);
 		}
-		free(configPath);
+		free(config_path);
 	}
 }
 #endif

--- a/cli-runopts.c
+++ b/cli-runopts.c
@@ -672,10 +672,11 @@ static void parse_multihop_hostname(const char* orighostarg, const char* argv0) 
 static void parse_hostname(const char* orighostarg) {
 	char *userhostarg = NULL;
 	char *port = NULL;
+	char* remotehost = NULL;
 
 	userhostarg = m_strdup(orighostarg);
 
-	char* remotehost = strchr(userhostarg, '@');
+	remotehost = strchr(userhostarg, '@');
 	if (remotehost == NULL) {
 		/* no username portion, the cli-auth.c code can figure the
 		 * local user's name */

--- a/dbclient.1
+++ b/dbclient.1
@@ -1,4 +1,4 @@
-.TH dbclient 1
+.TH dbclient 1 2023-02-01
 .SH NAME
 dbclient \- lightweight SSH client
 .SH SYNOPSIS
@@ -21,7 +21,6 @@ dbclient \- lightweight SSH client
 .B dbclient
 is the client part of Dropbear SSH
 .SH OPTIONS
-.TP
 .TP
 .B command
 A command to run on the remote host. This will normally be run by the remote host
@@ -222,6 +221,52 @@ SSH_ASKPASS should be set to the path of a program that will return a password
 on standard output. This program will only be used if either DISPLAY is set and
 standard input is not a TTY, or the environment variable SSH_ASKPASS_ALWAYS is
 set.
+
+.SH FILES
+.B ~/.ssh/dropbear_config
+
+This is the per user configuration file. A very limited subset of the keywords for
+ssh_config(5) is supported, and none of the advanced features. The file contains
+key value pairs on a single line separated with space or '='. Empty lines are ignored.
+Text starting with '#' is a comment, and also ignored.
+
+The file is not considered if multi-hop connection is used. Values on the command line
+override the respective values in the file.
+
+The recognized keywords are as follows. Keywords are case insensitive and values are
+case insensitive.
+
+.TP
+.B Host
+Defines the options that would be applied if this value matches the host specified
+on the command line. The next Host entry or EOF determine the list of applicable
+options.
+
+.TP
+.B HostName
+Specifies the actual host name to connect to. Can be DNS name or IP address.
+
+.TP
+.B Port
+Specifies the port number to use to connect to the remote host.
+
+.TP
+.B 
+User
+Specifies the user name to login in as.
+
+.TP
+.B
+IdentityFile
+Specifies the file with the private key used for public key authentication with the remote
+host. The file must be in the Dropbear format. See dropbearkey(1) to generate one. A '~/' at
+the start of the path will expanded to the executing user's home directory. A path that
+does not start with '/' will be treated relative to this configuration file's directory. Otherwise
+the path will be used as is.
+
+Because this file contains a secret it must have strict permissions to prevent abuse
+attempts - read/write for the executing user, and no access to anyone else.
+
 .SH NOTES
 If compiled with zlib support and if the server supports it, dbclient will
 always use compression.

--- a/default_options.h
+++ b/default_options.h
@@ -166,7 +166,7 @@ IMPORTANT: Some options will require "make clean" after changes */
 /* ECDSA defaults to largest size configured, usually 521 */
 /* Ed25519 is always 256 */
 
-/* Add runtime flag "-R" to generate hostkeys as-needed when the first 
+/* Add runtime flag "-R" to generate hostkeys as-needed when the first
    connection using that key type occurs.
    This avoids the need to otherwise run "dropbearkey" and avoids some problems
    with badly seeded /dev/urandom when systems first boot. */
@@ -182,7 +182,7 @@ IMPORTANT: Some options will require "make clean" after changes */
  * curve25519 - elliptic curve DH
  * ecdh - NIST elliptic curve DH (256, 384, 521)
  *
- * group1 is too small for security though is necessary if you need 
+ * group1 is too small for security though is necessary if you need
      compatibility with some implementations such as Dropbear versions < 0.53
  * group14 is supported by most implementations.
  * group16 provides a greater strength level but is slower and increases binary size
@@ -212,7 +212,7 @@ group1 in Dropbear server too */
  * windowBits=8 will use 129kB for compression.
  * Both modes will use ~35kB for decompression (using windowBits=15 for
  * interoperability) */
-#define DROPBEAR_ZLIB_WINDOW_BITS 15 
+#define DROPBEAR_ZLIB_WINDOW_BITS 15
 
 /* Whether to do reverse DNS lookups. */
 #define DO_HOST_LOOKUP 0
@@ -237,7 +237,7 @@ group1 in Dropbear server too */
  * You must define DROPBEAR_SVR_PUBKEY_AUTH in order to use plugins. */
 #define DROPBEAR_SVR_PUBKEY_AUTH 1
 
-/* Whether to take public key options in 
+/* Whether to take public key options in
  * authorized_keys file into account */
 #define DROPBEAR_SVR_PUBKEY_OPTIONS 1
 
@@ -259,9 +259,9 @@ group1 in Dropbear server too */
 */
 #define DROPBEAR_DEFAULT_SSH_CONFIG "~/.ssh/dropbear_config"
 
-/* Do not enable the config feature yet.
+/* Do not yet enable the per client configuration file feature.
 */
-#define DROPBEAR_DEFAULT_USE_SSH_CONFIG 0
+#define DROPBEAR_USE_SSH_CONFIG 0
 
 /* Allow specifying the password for dbclient via the DROPBEAR_PASSWORD
  * environment variable. */
@@ -275,8 +275,8 @@ group1 in Dropbear server too */
 #define DROPBEAR_CLI_ASKPASS_HELPER 0
 
 /* Save a network roundtrip by sendng a real auth request immediately after
- * sending a query for the available methods. This is not yet enabled by default 
- since it could cause problems with non-compliant servers */ 
+ * sending a query for the available methods. This is not yet enabled by default
+ since it could cause problems with non-compliant servers */
 #define DROPBEAR_CLI_IMMEDIATE_AUTH 0
 
 /* Set this to use PRNGD or EGD instead of /dev/urandom */
@@ -288,7 +288,7 @@ group1 in Dropbear server too */
 /* The first setting is per-IP, to avoid denial of service */
 #define MAX_UNAUTH_PER_IP 5
 
-/* And then a global limit to avoid chewing memory if connections 
+/* And then a global limit to avoid chewing memory if connections
  * come from many IPs */
 #define MAX_UNAUTH_CLIENTS 30
 
@@ -298,7 +298,7 @@ group1 in Dropbear server too */
 
 /* Delay introduced before closing an unauthenticated session (seconds).
    Disabled by default, can be set to say 30 seconds to reduce the speed
-   of password brute forcing. Note that there is a risk of denial of 
+   of password brute forcing. Note that there is a risk of denial of
    service by setting this */
 #define UNAUTH_CLOSE_DELAY 0
 
@@ -325,8 +325,8 @@ group1 in Dropbear server too */
  * not using the Dropbear client, you'll need to change it */
 #define DROPBEAR_PATH_SSH_PROGRAM "/usr/bin/dbclient"
 
-/* Whether to log commands executed by a client. This only logs the 
- * (single) command sent to the server, not what a user did in a 
+/* Whether to log commands executed by a client. This only logs the
+ * (single) command sent to the server, not what a user did in a
  * shell/sftp session etc. */
 #define LOG_COMMANDS 0
 

--- a/default_options.h
+++ b/default_options.h
@@ -255,6 +255,14 @@ group1 in Dropbear server too */
  */
 #define DROPBEAR_DEFAULT_CLI_AUTHKEY "~/.ssh/id_dropbear"
 
+/* Default per client configuration file.
+*/
+#define DROPBEAR_DEFAULT_SSH_CONFIG "~/.ssh/dropbear_config"
+
+/* Do not enable the config feature yet.
+*/
+#define DROPBEAR_DEFAULT_USE_SSH_CONFIG 0
+
 /* Allow specifying the password for dbclient via the DROPBEAR_PASSWORD
  * environment variable. */
 #define DROPBEAR_USE_PASSWORD_ENV 1

--- a/runopts.h
+++ b/runopts.h
@@ -149,6 +149,7 @@ typedef struct cli_runopts {
 
 	char *progname;
 	char *remotehost;
+	int remotehostfixed;
 	const char *remoteport;
 
 	char *own_user;
@@ -204,5 +205,9 @@ void parse_ciphers_macs(void);
 void print_version(void);
 void parse_recv_window(const char* recv_window_arg);
 int split_address_port(const char* spec, char **first, char ** second);
+
+#if DROPBEAR_DEFAULT_USE_SSH_CONFIG
+void read_config_file(char* filename, FILE* configFile, cli_runopts* options);
+#endif
 
 #endif /* DROPBEAR_RUNOPTS_H_ */

--- a/runopts.h
+++ b/runopts.h
@@ -1,19 +1,19 @@
 /*
  * Dropbear - a SSH2 server
- * 
+ *
  * Copyright (c) 2002,2003 Matt Johnston
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -63,7 +63,7 @@ typedef struct runopts {
 
 extern runopts opts;
 
-int readhostkey(const char * filename, sign_key * hostkey, 
+int readhostkey(const char * filename, sign_key * hostkey,
 	enum signkey_type *type);
 void load_all_hostkeys(void);
 
@@ -97,7 +97,7 @@ typedef struct svr_runopts {
 	int norootlogin;
 
 #ifdef HAVE_GETGROUPLIST
-	/* restrict_group is the group name if group restriction was enabled, 
+	/* restrict_group is the group name if group restriction was enabled,
 	NULL otherwise */
 	char *restrict_group;
 	/* restrict_group_gid is only valid if restrict_group is set */
@@ -129,7 +129,7 @@ typedef struct svr_runopts {
 
 	char * forced_command;
 
-#if DROPBEAR_PLUGIN 
+#if DROPBEAR_PLUGIN
 	/* malloced */
 	char *pubkey_plugin;
 	/* points into pubkey_plugin */
@@ -178,7 +178,7 @@ typedef struct cli_runopts {
 #endif
 #if DROPBEAR_CLI_AGENTFWD
 	int agent_fwd;
-	int agent_keys_loaded; /* whether pubkeys has been populated with a 
+	int agent_keys_loaded; /* whether pubkeys has been populated with a
 							  list of keys held by the agent */
 	int agent_fd; /* The agent fd is only set during authentication. Forwarded
 	                 agent sessions have their own file descriptors */
@@ -206,8 +206,8 @@ void print_version(void);
 void parse_recv_window(const char* recv_window_arg);
 int split_address_port(const char* spec, char **first, char ** second);
 
-#if DROPBEAR_DEFAULT_USE_SSH_CONFIG
-void read_config_file(char* filename, FILE* configFile, cli_runopts* options);
+#if DROPBEAR_USE_SSH_CONFIG
+void read_config_file(char* filename, FILE* config_file, cli_runopts* options);
 #endif
 
 #endif /* DROPBEAR_RUNOPTS_H_ */


### PR DESCRIPTION
I have a number of OpenWRT routers, and all are running Dropbear SSH. For various reasons I ssh to other machines from the routers. A file like that OpenSSH one (~/.ssh/config) would be handy. It's not the first time I was looking for that feature, but now I came across this comment by Matt Johnston:

> ... but I'd be happy to take a patch if someone wants to make it work.

(https://www.mail-archive.com/dropbear@ucc.asn.au/msg01914.html)

Well, here's an offer for review.

The support is minimalistic. Just the very basics - an alias that defines the real remote host, port number, user name, and identity file to use. This covers all of my use cases, and probably most for others. Then again, as Matt says in the comment above, the same can be accomplished with appropriately named scripts. Still, it opens the possibility to add more advanced capabilities.

The support for the config file is not compiling by default. It is behind the `DROPBEAR_DEFAULT_USE_SSH_CONFIG` define, which can be enabled in the `localoptions.h` if this feature gets vetted.

The config file is hard coded to `~/.ssh/dropbear_config`. I tested using the OpenSSH `~/.ssh/config` as the keywords are the same. There were no issues for either client. But that may not be the case in the future. And it's easy to see problems with having what are distinctly separate semantics being merged into a single file.

All the tests I ran were manual. I see there is some test harness in [test](./test), but I was not able to run it successfully. And could not find documentation about it in the source.

Updated the [dbclient.1](./dbclient.1) manpage, **Files** section. Normally a configuration file would have its own manpage, but I decided this one was too simple for that.

tjk :)