### PR TITLE
Change port separator to semicolon : since it's more standard

### DIFF
--- a/manpages/dbclient.1
+++ b/manpages/dbclient.1
@@ -15,7 +15,7 @@ dbclient \- lightweight SSH client
 
 .B dbclient
 [\fIargs\fR]
-[\fIuser1\fR]@\fIhost1\fR[^\fIport1\fR],[\fIuser2\fR]@\fIhost2\fR[^\fIport2\fR],...
+[\fIuser1\fR]@\fIhost1\fR[:\fIport1\fR],[\fIuser2\fR]@\fIhost2\fR[:\fIport2\fR],...
 
 .SH DESCRIPTION
 .B dbclient
@@ -32,7 +32,7 @@ host argument. If no command is specified an interactive terminal will be opened
 .B \-p \fIport
 Connect to 
 .I port
-on the remote host. Alternatively a port can be specified as hostname^port.
+on the remote host. Alternatively a port can be specified as hostname:port.
 Default is 22.
 .TP
 .B \-i \fIidfile
@@ -194,7 +194,7 @@ Dropbear will also allow multiple "hops" to be specified, separated by commas. I
 this case a connection will be made to the first host, then a TCP forwarded 
 connection will be made through that to the second host, and so on. Hosts other than
 the final destination will not see anything other than the encrypted SSH stream. 
-A port for a host can be specified with a caret (eg matt@martello^44 ).
+A port for a host can be specified with a caret (eg matt@martello:44 ).
 This syntax can also be used with scp or rsync (specifying dbclient as the 
 ssh/rsh command). A file can be "bounced" through multiple SSH hops, eg
 
@@ -205,7 +205,7 @@ in the example above, the same way as other -L TCP forwarded hosts are. Host key
 checked locally based on the given hostname.
 
 .SH ESCAPE CHARACTERS
-Typing a newline followed by the  key sequence \fI~.\fR (tilde, dot) will terminate a connection.
+Typing a newline followed by the key sequence \fI~.\fR (tilde, dot) will terminate a connection.
 The sequence \fI~^Z\fR (tilde, ctrl-z) will background the connection. This behaviour only
 applies when a PTY is used.
 

--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -657,7 +657,7 @@ static void parse_multihop_hostname(const char* orighostarg, const char* argv0) 
 }
 #endif /* !DROPBEAR_CLI_MULTIHOP */
 
-/* Parses a [user@]hostname[/port] argument. */
+/* Parses a [user@]hostname[:port] argument. */
 static void parse_hostname(const char* orighostarg) {
 	char *userhostarg = NULL;
 	char *port = NULL;
@@ -679,10 +679,14 @@ static void parse_hostname(const char* orighostarg) {
 		cli_opts.username = m_strdup(cli_opts.own_user);
 	}
 
-	port = strchr(cli_opts.remotehost, '^');
+	port = strchr(cli_opts.remotehost, ':');
 	if (!port)  {
-		/* legacy separator */
-		port = strchr(cli_opts.remotehost, '/');
+		/* legacy separator '^' */
+		port = strchr(cli_opts.remotehost, '^');
+		if (!port)  {
+			/* legacy separator '/' */
+			port = strchr(cli_opts.remotehost, '/');
+		}
 	}
 	if (port) {
 		*port = '\0';


### PR DESCRIPTION
Kindly suggesting to switch to semicolon character `:` as port separator as `[user@]hostname[:port]`.  Current port separator is `^` which is less standard -- semicolon is used both in `ssh` and `scp` programs.

For maintaining backward compatibility, similar to the support of legacy `/`, the character `^` can still be supported.

Appendix
--------

A bit of history:

 - From what I've been able to understand from Git history, everything started in 2008 with the usage of `/` as port separator, implemented in [1].

 - Five years later, in 2013, This was changed [2] to `#` to fix a problem related to `scp`.  Not sure, but a plausible reason for this could be a clash with the usage of `/` for directories.  Note that the usage of `/` was still allowed as legacy.

 - That same year it was changed again [3] to `%` for some reason I have not been able to understand.

 - Then, in 2014, since `%` is used by IPv6 addresses, this was changed [4] to use `^` as port separator -- and this is the current state.

As a comment, `/` is still supported as legacy.

[1]: https://github.com/mkj/dropbear/commit/d981ff2c8dcb5c3d3740b26d434e043340368e8b
[2]: https://github.com/mkj/dropbear/commit/3525cabf48eb97d2e58a1e715e70fab399d40568
[3]: https://github.com/mkj/dropbear/commit/f98eb5808bd5fbdf7463f2d7233bb3cc52b12f89
[4]: https://github.com/mkj/dropbear/commit/0c9a643216e330911917fb1837747456d49a80b2