### PR TITLE
Add to SCP binary the possibility to skip host check

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -326,7 +326,7 @@ main(int argc, char **argv)
 	addargs(&args, "%s", ssh_program);
 
 	fflag = tflag = 0;
-	while ((ch = getopt(argc, argv, "dfl:prtvBCc:i:P:q1246S:o:F:")) != -1)
+	while ((ch = getopt(argc, argv, "dfl:prtvBCc:i:P:qy1246S:o:F:")) != -1)
 		switch (ch) {
 		/* User-visible flags. */
 		case '1':
@@ -334,6 +334,7 @@ main(int argc, char **argv)
 		case '4':
 		case '6':
 		case 'C':
+		case 'y':
 			addargs(&args, "-%c", ch);
 			break;
 		case 'o':


### PR DESCRIPTION
The `ssh` client provided by dropbear give the user a way to accept/skip host validation check using -y option, the -y option can be specified once to get something like this (accept):

```
/usr/bin/dhclient: 
Host '10.0.0.237' key accepted unconditionally.
```

Or twice to skip the validation:

```
/usr/bin/dhclient: Caution, skipping hostkey check for 10.0.0.237
```

This PR adds the same capability to the `scp` command:

```
iMac-2 $ /tmp/dropbear/bin/scp -y release.sh root@10.0.0.237:/tmp
/tmp/dropbear/bin/dhclient: 
Host '10.0.0.237' key accepted unconditionally.
(ssh-rsa fingerprint SHA256:QKOF+XXXXXXXXXXXXX)
root@10.0.0.237's password: 
```

or

```
iMac-2 $ /tmp/dropbear/bin/scp -y -y release.sh root@10.0.0.237:/tmp
/tmp/dropbear/bin/dhclient: Caution, skipping hostkey check for 10.0.0.237
root@10.0.0.237's password: 
```

