### PR TITLE
if test "t$found_crypt_func" = here; then typo?

### DIFF
--- a/configure
+++ b/configure
@@ -9988,7 +9988,7 @@ printf "%s\n" "$as_me: " >&6;}
 printf "%s\n" "$as_me: getpass() not available, dbclient will only have public-key authentication" >&6;}
 fi
 
-if test "t$found_crypt_func" != there; then
+if test "t$found_crypt_func" != here; then
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: " >&5
 printf "%s\n" "$as_me: " >&6;}
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: crypt() not available, dropbear server will not have password authentication" >&5

--- a/configure
+++ b/configure
@@ -5388,7 +5388,7 @@ then :
 fi
 
 
-if test "t$found_crypt_func" = there; then
+if test "t$found_crypt_func" = here; then
 
 printf "%s\n" "#define HAVE_CRYPT 1" >>confdefs.h
 


### PR DESCRIPTION
I don't see how $found_crypt_func would ever be set to `there`, only ever `here`?