### PR TITLE
cygwin github action + sysoptions workaround

### DIFF
--- a/.github/workflows/cygwin-build.yaml
+++ b/.github/workflows/cygwin-build.yaml
@@ -1,0 +1,31 @@
+name: Cygwin Build
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      SHELLOPTS: igncr
+    defaults:
+      run:
+        shell: C:/tools/cygwin/bin/bash.exe --login '{0}'
+    steps:
+      - uses: egor-tensin/setup-cygwin@v4
+        with:
+          install-dir: C:/tools/cygwin
+          packages: gcc-core gcc-g++ autoconf automake libtool pkg-config make zlib-devel libcrypt-devel libtommath-devel cygwin-devel
+      - run: git config --global core.autocrlf false
+      - run: git config --system core.eol lf
+      - uses: actions/checkout@v2
+      - run: cd $GITHUB_WORKSPACE; autoreconf --verbose --force
+      - run: cd $GITHUB_WORKSPACE; ./configure
+      - run: cd $GITHUB_WORKSPACE; make PROGRAMS="dropbear dbclient dropbearkey dropbearconvert scp"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dropbear
+          path: |
+            ${{ github.workspace }}/dropbear.exe
+            ${{ github.workspace }}/dbclient.exe
+            ${{ github.workspace }}/dropbearkey.exe
+            ${{ github.workspace }}/dropbearconvert.exe
+            ${{ github.workspace }}/scp.exe

--- a/src/sysoptions.h
+++ b/src/sysoptions.h
@@ -3,6 +3,13 @@
  * This file is only included from options.h
  *******************************************************************/
 
+/* TODO: find a better workaround */
+#ifdef __CYGWIN__
+#ifndef HAVE_SYS_RANDOM_H
+#define HAVE_SYS_RANDOM_H 1
+#endif
+#endif
+
 #ifndef DROPBEAR_VERSION
 #define DROPBEAR_VERSION "2022.83"
 #endif


### PR DESCRIPTION
I doubt this will get actually upstreamed but it helped me today so I hope it helps somebody else.

https://cygwin.com/packages/x86_64/cygwin-devel/cygwin-devel-3.4.9-1 says `2023-09-06 11:29         581 usr/include/sys/random.h` is provided but `autoreconf` couldn't find it for some reason.

I also tried to do `--enable-static` (to avoid the need for the Cygwin runtime being installed/the binaries being linked externally against the Cygwin runtime DLLs) but it had a hard time with `-lcrypto` (it probably isn't provided in a fashion that can be used statically from https://cygwin.com/packages/x86_64/libcrypt-devel/libcrypt-devel-4.4.20-1 (although I do see `usr/lib/libcrypt.dll.a`)

## How to use:

```shell
# build it with GitHub Actions + download: https://github.com/brandonros/dropbear/actions/runs/6964141533
# install Cygwin on the machine (probably need libcrypt package) or figure out Cygwin runtime DLLs
# run it from Cygwin terminal, not Git Bash or MinGW (freaks out about being able to write to /etc/dropbear for host keys)
mkpasswd -l > /etc/passwd
mkgroup -l > /etc/group
mkdir /etc/dropbear
mkdir ~/.ssh/
vi ~/.ssh/authorized_keys # paste ~/.ssh/id_rsa.pub from client into it, do not try to connect with passwords
./dropbear -F -E -R -w -s -g -j -k
```