### PR TITLE
Use src/distrooptions.h as another source

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,15 @@
 ## Basic Dropbear Build Instructions
 
-Edit [localoptions.h](./localoptions.h) to set which features you want.
-Available options are described in default_options.h.
-They will be overridden by anything set in [localoptions.h](./localoptions.h) should be located in the build directory if you are building out of tree.
-Note that the file is not tracked ([.gitignore](.gitignore)-d) and you may need to create it.
+### Build Options
 
-#### Configure for your system
+Custom build options can be configured in `localoptions.h` in the build directory. This is a local file, not checked in to git.
+
+Available options are described in [`src/default_options.h`](src/default_options.h)
+Options include available cryptographic algorithms, SSH features, and file paths.
+
+In addition, a `src/distrooptions.h` file will be used if it exists, for distributions to set configuration options.
+
+### Configure for your system
 ```
 ./configure
 ```
@@ -14,7 +18,7 @@ Or `--help` for other options.
 
 You'll need to first run `autoconf; autoheader` if you edit `configure.ac`.
 
-#### Compile:
+### Compile:
 
 ```
 make PROGRAMS="dropbear dbclient dropbearkey dropbearconvert scp"

--- a/Makefile.in
+++ b/Makefile.in
@@ -27,10 +27,11 @@ ifeq (@BUNDLED_LIBTOM@, 1)
 	LIBTOM_LIBS=$(STATIC_LTC) $(STATIC_LTM)
 endif
 
-OPTION_HEADERS = default_options_guard.h $(srcdir)/sysoptions.h
 ifneq ($(wildcard ./localoptions.h),)
 	CPPFLAGS+=-DLOCALOPTIONS_H_EXISTS
-	OPTION_HEADERS += ./localoptions.h
+endif
+ifneq ($(wildcard $(srcdir)/distrooptions.h),)
+	CPPFLAGS+=-DDISTROOPTIONS_H_EXISTS
 endif
 
 OBJ_DIR=./obj
@@ -159,7 +160,7 @@ endif
 all: $(TARGETS)
 
 # for simplicity assume all source depends on all headers
-HEADERS=$(wildcard $(srcdir)/*.h *.h) $(OPTION_HEADERS)
+HEADERS=$(wildcard $(srcdir)/*.h *.h) default_options_guard.h
 
 $(OBJ_DIR):
 	mkdir -p $@
@@ -250,10 +251,10 @@ link%:
 	-rm -f $*$(EXEEXT)
 	-ln -s dropbearmulti$(EXEEXT) $*$(EXEEXT)
 
-$(STATIC_LTC): $(OPTION_HEADERS)
+$(STATIC_LTC): $(HEADERS)
 	$(MAKE) -C libtomcrypt
 
-$(STATIC_LTM): $(OPTION_HEADERS)
+$(STATIC_LTM): $(HEADERS)
 	$(MAKE) -C libtommath
 
 .PHONY : clean sizes thisclean distclean tidy ltc-clean ltm-clean lint check

--- a/src/default_options.h
+++ b/src/default_options.h
@@ -3,11 +3,13 @@
 /*
                      > > > Read This < < <
 
-default_options.h  documents compile-time options, and provides default values.
+default_options.h documents compile-time options, and provides default values.
 
 Local customisation should be added to localoptions.h which is
 used if it exists in the build directory. Options defined there will override
 any options in this file.
+
+Customisations will also be taken from src/distoptions.h if it exists.
 
 Options can also be defined with -DDROPBEAR_XXX=[0,1] in Makefile CFLAGS
 

--- a/src/options.h
+++ b/src/options.h
@@ -1,17 +1,22 @@
 #ifndef DROPBEAR_OPTIONS_H
 #define DROPBEAR_OPTIONS_H
 
-/* 
-            > > > Don't edit this file any more! < < <
-            
+/*
 Local compile-time configuration should be defined in localoptions.h
-in the build directory.
+in the build directory, or src/distrooptions.h
 See default_options.h.in for a description of the available options.
 */
 
 /* Some configuration options or checks depend on system config */
 #include "config.h"
 
+/* Distribution custom build options, used if it exists */
+#ifdef DISTROOPTIONS_H_EXISTS
+#include "distrooptions.h"
+#endif
+
+/* Local compile-time configuration in the build directory,
+ * used if it exists */
 #ifdef LOCALOPTIONS_H_EXISTS
 #include "localoptions.h"
 #endif


### PR DESCRIPTION
This makes it easier for distributions to patch the source directory, rather than needing to create localoptions.h in the build directory.

Makefile's OPTION_HEADERS is removed, the wildcard *.h covers it