### PR TITLE
Define MOTD_MAXSIZE in default_options.h

### DIFF
--- a/src/default_options.h
+++ b/src/default_options.h
@@ -221,6 +221,7 @@ group1 in Dropbear server too */
 /* Whether to print the message of the day (MOTD). */
 #define DO_MOTD 1
 #define MOTD_FILENAME "/etc/motd"
+#define MOTD_MAXSIZE 2000 
 
 /* Authentication Types - at least one required.
    RFC Draft requires pubkey auth, and recommends password */

--- a/src/svr-chansession.c
+++ b/src/svr-chansession.c
@@ -875,9 +875,11 @@ static int ptycommand(struct Channel *channel, struct ChanSess *chansess) {
 			if (stat(hushpath, &sb) < 0) {
 				char *expand_path = NULL;
 				/* more than a screenful is stupid IMHO */
-				motdbuf = buf_new(80 * 25);
+				motdbuf = buf_new(MOTD_MAXSIZE);
 				expand_path = expand_homedir_path(MOTD_FILENAME);
 				if (buf_readfile(motdbuf, expand_path) == DROPBEAR_SUCCESS) {
+					/* incase it is full size, add LF at last position */
+					if (motdbuf->len == motdbuf->size) motdbuf->data[motdbuf->len - 1]=10;
 					buf_setpos(motdbuf, 0);
 					while (motdbuf->pos != motdbuf->len) {
 						len = motdbuf->len - motdbuf->pos;

--- a/src/sysoptions.h
+++ b/src/sysoptions.h
@@ -68,6 +68,11 @@
 #define MAX_BANNER_SIZE 2050 /* this is 25*80 chars, any more is foolish */
 #define MAX_BANNER_LINES 20 /* How many lines the client will display */
 
+/* Define maxsize for motd information (80 x 25) */
+#ifndef MOTD_MAXSIZE
+#define MOTD_MAXSIZE 2000
+#endif
+
 /* the number of NAME=VALUE pairs to malloc for environ, if we don't have
  * the clearenv() function */
 #define ENV_SIZE 100


### PR DESCRIPTION
add MOTD_MAXSIZE 2000 in default_options.h instead of hard coded value (80 * 25) in svr_chansession.c

This way you can increase the value in local_options.h if really needed.
