### PR TITLE
Don't ftruncate() non-regular files

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -1051,9 +1051,10 @@ bad:			run_err("%s: %s", np, strerror(errno));
 			wrerr = YES;
 			wrerrno = errno;
 		}
-		if (wrerr == NO && ftruncate(ofd, size) != 0) {
-			run_err("%s: truncate: %s", np, strerror(errno));
-			wrerr = DISPLAYED;
+		if (wrerr == NO && (!exists || S_ISREG(stb.st_mode)) &&
+			ftruncate(ofd, size) != 0) {
+				run_err("%s: truncate: %s", np, strerror(errno));
+				wrerr = DISPLAYED;
 		}
 		if (pflag) {
 			if (exists || omode != mode)


### PR DESCRIPTION
Port of [bug fix in openssh scp](https://github.com/openssh/openssh-portable/commit/067263e84800c4b35f9bbbfafdd92aea493b6e0b) to not ftruncate non-regular files (i.e. FIFO or device node).

Original openssh bug is at https://bugzilla.mindrot.org/show_bug.cgi?id=1236

This will avoid abnormal termination errors.