### PR TITLE
Remove /proc/timer_list as an entropy source

### DIFF
--- a/src/dbrandom.c
+++ b/src/dbrandom.c
@@ -268,9 +268,6 @@ void seedrandom() {
 	/* A few other sources to fall back on. 
 	 * Add more here for other platforms */
 #ifdef __linux__
-	/* Seems to be a reasonable source of entropy from timers. Possibly hard
-	 * for even local attackers to reproduce */
-	process_file(&hs, "/proc/timer_list", 0, 0);
 	/* Might help on systems with wireless */
 	process_file(&hs, "/proc/interrupts", 0, 0);
 


### PR DESCRIPTION
It is a CPU bottleneck.

Fixes #276 on github