### PR TITLE
cli-runopts.c add missing DROPBEAR_CLI_PUBKEY_AUTH

### DIFF
--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -567,11 +567,13 @@ static char* multihop_passthrough_args(void) {
 	if (cli_opts.proxycmd) {
 		len += strlen(cli_opts.proxycmd);
 	}
+#if DROPBEAR_CLI_PUBKEY_AUTH
 	for (iter = cli_opts.privkeys->first; iter; iter = iter->next)
 	{
 		sign_key * key = (sign_key*)iter->item;
 		len += 4 + strlen(key->filename);
 	}
+#endif
 
 	args = m_malloc(len);
 	total = 0;


### PR DESCRIPTION
Fix build when `#define DROPBEAR_CLI_PUBKEY_AUTH 0`:

```
src/cli-runopts.c: In function ‘multihop_passthrough_args’:
src/cli-runopts.c:570:29: error: ‘cli_runopts’ has no member named ‘privkeys’
  570 |         for (iter = cli_opts.privkeys->first; iter; iter = iter->next)
      |                             ^
```
