### PR TITLE
sysoptions.h: move keepalive string above ident

### DIFF
--- a/src/sysoptions.h
+++ b/src/sysoptions.h
@@ -7,6 +7,9 @@
 #define DROPBEAR_VERSION "2024.85"
 #endif
 
+/* Use this string since some implementations might special-case it */
+#define DROPBEAR_KEEPALIVE_STRING "keepalive@openssh.com"
+
 #define LOCAL_IDENT "SSH-2.0-dropbear_" DROPBEAR_VERSION
 #define PROGNAME "dropbear"
 
@@ -364,9 +367,6 @@
 
 /* free memory before exiting */
 #define DROPBEAR_CLEANUP 1
-
-/* Use this string since some implementations might special-case it */
-#define DROPBEAR_KEEPALIVE_STRING "keepalive@openssh.com"
 
 /* Linux will attempt TCP fast open, falling back if not supported by the kernel.
  * Currently server is enabled but client is disabled by default until there


### PR DESCRIPTION
OpenWrt package removes Dropbear version from ident string. Until now, that was done with sed, instead of a patch. I'm trying to change that to a patch.

I noticed that the version string is defined only 3 lines above the ident string. A normal patch would include the version line. Any version change would invalidate the patch.

To keep the version string outside the patch. I moved the keepalive string just above the ident string, as these are somewhat related.

If you don't like this PR, an alternative would be to add a comment-description of the ident string. That would also push the the version string outside the patch.

Thanks.