### PR TITLE
Re-add host to "Login attempt for nonexistent user" log

### DIFF
--- a/src/svr-auth.c
+++ b/src/svr-auth.c
@@ -265,7 +265,8 @@ static int checkusername(const char *username, unsigned int userlen) {
 	if (!ses.authstate.pw_name) {
 		TRACE(("leave checkusername: user '%s' doesn't exist", username))
 		dropbear_log(LOG_WARNING,
-				"Login attempt for nonexistent user");
+				"Login attempt for nonexistent user from %s",
+				svr_ses.addrstring);
 		ses.authstate.checkusername_failed = 1;
 		return DROPBEAR_FAILURE;
 	}


### PR DESCRIPTION
https://github.com/mkj/dropbear/pull/83 removed the host from the final message part of early exit messages, and added it to the initial message part instead. This was however done for "Login attempt for nonexistent user" as well, which is no early exit message, but allows the client to keep trying. Those log entries hence now do not contain a host anymore.

This PR reverts this part of https://github.com/mkj/dropbear/pull/83 to restore the missing host, and re-enable software like Fail2Ban to track these login failures.

___________

As mentioned in #83, I guess "Login attempt with wrong user" (when Dropbear runs as non-root user) is no early exit message as well, and hence needs to be reverted the same way. Probably someone can verify this quicker than me.