### PR TITLE
libtomcrypt: fix vulnerability in der_decode_utf8_string CVE-2019-17362

### DIFF
--- a/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
+++ b/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
@@ -76,7 +76,7 @@ int der_decode_utf8_string(const unsigned char *in,  unsigned long inlen,
       /* count number of bytes */
       for (z = 0; (tmp & 0x80) && (z <= 4); z++, tmp = (tmp << 1) & 0xFF);
 
-      if (z > 4 || (x + (z - 1) > inlen)) {
+      if (z == 1 || z > 4 || (x + (z - 1) > inlen)) {
          return CRYPT_INVALID_PACKET;
       }
 


### PR DESCRIPTION
[ cherry pick of upstream commit [64d1153e5a515740ab56f39c46baf4cf6991a9d3](https://github.com/libtom/libtomcrypt/commit/64d1153e5a515740ab56f39c46baf4cf6991a9d3) ]

The der_decode_utf8_string function (in der_decode_utf8_string.c) does not properly detect certain invalid UTF-8 sequences.  This allows context-dependent attackers to cause a denial of service (out-of-bounds read and crash) or read information from other memory locations via carefully crafted DER-encoded data.

To exploit this vulnerability an attacker must be able to provide crafted DER-encoded data to LibTomCrypt (e.g. by importing a X509 certificate).  Information disclosure is made possible by a 2-steps attack where the imported data is later somehow re-encoded and sent to the attacker (e.g. import and then export X509 certificate).

Fixes: CVE-2019-17362
References: https://github.com/libtom/libtomcrypt/issues/507