### PR TITLE
Don't close channels when a PID hasn't started

### DIFF
--- a/src/common-channel.c
+++ b/src/common-channel.c
@@ -317,7 +317,8 @@ static void check_close(struct Channel *channel) {
 
 	if ((channel->recv_eof && !write_pending(channel))
 		/* have a server "session" and child has exited */
-		|| (channel->type->check_close && close_allowed)) {
+		|| (channel->writefd != FD_UNINIT
+			&& channel->type->check_close && close_allowed)) {
 		close_chan_fd(channel, channel->writefd, SHUT_WR);
 	}
 


### PR DESCRIPTION
If check_close() ran prior to a server channel exec/shell request, it would send a close immediately.
This fix changes it to exclude write_fd==FD_UNINIT from being closed there.

When a channel was closed by the time shell/exec request was received, then data sent hits an assertion.
This fixes #321 on Github.

The "pid == 0" check was initially added to avoid waiting to close a channel when a process has never been launched (which is correct), but that isn't correct in the case of the closed-fd test.

Fixes: 8e6f73e879ca ("- Remove "flushing" handling for exited processes)