### PR TITLE
Split compression s2c/c2s, disable server c2s

### DIFF
--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -182,7 +182,7 @@ void cli_getopts(int argc, char ** argv) {
 	cli_opts.bind_port = NULL;
 	cli_opts.keepalive_arg = NULL;
 #ifndef DISABLE_ZLIB
-	opts.compress_mode = DROPBEAR_COMPRESS_ON;
+	opts.allow_compress = 1;
 #endif
 #if DROPBEAR_USER_ALGO_LIST
 	opts.cipher_list = NULL;
@@ -681,7 +681,7 @@ static void parse_multihop_hostname(const char* orighostarg, const char* argv0) 
 				passthrough_args, remainder);
 #ifndef DISABLE_ZLIB
 		/* The stream will be incompressible since it's encrypted. */
-		opts.compress_mode = DROPBEAR_COMPRESS_OFF;
+		opts.allow_compress = 0;
 #endif
 		m_free(passthrough_args);
 	}

--- a/src/runopts.h
+++ b/src/runopts.h
@@ -44,14 +44,9 @@ typedef struct runopts {
 	int usingsyslog;
 
 #ifndef DISABLE_ZLIB
-	/* TODO: add a commandline flag. Currently this is on by default if compression
-	 * is compiled in, but disabled for a client's non-final multihop stages. (The
-	 * intermediate stages are compressed streams, so are uncompressible. */
-	enum {
-		DROPBEAR_COMPRESS_DELAYED, /* Server only */
-		DROPBEAR_COMPRESS_ON,
-		DROPBEAR_COMPRESS_OFF,
-	} compress_mode;
+	/* Whether any compression is allowed. The specific method used
+	 * varies between client and server, it will be set up by kex_setup_compress() */
+	int allow_compress;
 #endif
 
 #if DROPBEAR_USER_ALGO_LIST

--- a/src/session.h
+++ b/src/session.h
@@ -196,7 +196,8 @@ struct sshsession {
 							 can add it to the hash when generating keys */
 
 	/* Enables/disables compression */
-	algo_type *compress_algos;
+	algo_type *compress_algos_c2s;
+	algo_type *compress_algos_s2c;
 
 	/* Other side allows SSH_MSG_EXT_INFO. Currently only set for server */
 	int allow_ext_info;

--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -187,7 +187,7 @@ void svr_getopts(int argc, char ** argv) {
 	svr_opts.reexec_childpipe = -1;
 
 #ifndef DISABLE_ZLIB
-	opts.compress_mode = DROPBEAR_COMPRESS_DELAYED;
+	opts.allow_compress = 1;
 #endif 
 
 	/* not yet


### PR DESCRIPTION
Disable zlib entirely for server in the client to server direction. This avoids attack surface for zlib, and also saves 35kB runtime RAM for the decompression context. Interactive sessions don't have much traffic in the client->server direction so performance difference should not be noticable.