### PR TITLE
Re-add host to "Login attempt with wrong user" log

### DIFF
--- a/src/svr-auth.c
+++ b/src/svr-auth.c
@@ -276,8 +276,9 @@ static int checkusername(const char *username, unsigned int userlen) {
 	if (!(DROPBEAR_SVR_MULTIUSER && uid == 0) && uid != ses.authstate.pw_uid) {
 		TRACE(("running as nonroot, only server uid is allowed"))
 		dropbear_log(LOG_WARNING,
-				"Login attempt with wrong user %s",
-				ses.authstate.pw_name);
+				"Login attempt with wrong user %s from %s",
+				ses.authstate.pw_name,
+				svr_ses.addrstring);
 		ses.authstate.checkusername_failed = 1;
 		return DROPBEAR_FAILURE;
 	}


### PR DESCRIPTION
As discussed and fixed in #316 for "nonexistent user" logs, this commit additionally reverts #83 for "wrong user" logs, to re-add the remote host to the those log entries.