### PR TITLE
Run dropbear as for a single non-root user

### DIFF
--- a/src/auth.h
+++ b/src/auth.h
@@ -129,6 +129,7 @@ struct AuthState {
 	char *pw_shell;
 	char *pw_name;
 	char *pw_passwd;
+	char *org_username;		/* save org userid given and set this in envvar SSH_ORGUSER */
 #if DROPBEAR_SVR_PUBKEY_OPTIONS_BUILT
 	struct PubKeyOptions* pubkey_options;
 	char *pubkey_info;

--- a/src/default_options.h
+++ b/src/default_options.h
@@ -22,12 +22,15 @@ IMPORTANT: Some options will require "make clean" after changes */
 
 /* Default hostkey paths - these can be specified on the command line.
  * Homedir is prepended if path begins with ~/
+ * when running as root, default directory is /etc/dropbear
+ * when running with a nonroot user, default directory is ~/.ssh
+ * any other Homedir can be given during runtime with option -H ~/
  */
-#define DSS_PRIV_FILENAME "/etc/dropbear/dropbear_dss_host_key"
-#define RSA_PRIV_FILENAME "/etc/dropbear/dropbear_rsa_host_key"
-#define ECDSA_PRIV_FILENAME "/etc/dropbear/dropbear_ecdsa_host_key"
-#define ED25519_PRIV_FILENAME "/etc/dropbear/dropbear_ed25519_host_key"
-
+#define DSS_PRIV_FILENAME "dropbear_dss_host_key"
+#define RSA_PRIV_FILENAME "dropbear_rsa_host_key"
+#define ECDSA_PRIV_FILENAME "dropbear_ecdsa_host_key"
+#define ED25519_PRIV_FILENAME "dropbear_ed25519_host_key"
+ 
 /* Set NON_INETD_MODE if you require daemon functionality (ie Dropbear listens
  * on chosen ports and keeps accepting connections. This is the default.
  *

--- a/src/runopts.h
+++ b/src/runopts.h
@@ -127,6 +127,9 @@ typedef struct svr_runopts {
 	char * forced_command;
 	char* interface;
 
+	char *hostdir;
+	char *forceuser;
+
 #if DROPBEAR_PLUGIN
 	/* malloced */
 	char *pubkey_plugin;

--- a/src/svr-auth.c
+++ b/src/svr-auth.c
@@ -110,6 +110,16 @@ void recv_msg_userauth_request() {
 		dropbear_exit("unknown service in auth");
 	}
 
+	/* if we need to force logins to a specific user, this is a good place to do it. */
+	if (svr_opts.forceuser) {
+		/* first save original user, which we can specify in envvar SSH_ORGUSER */
+		ses.authstate.org_username = m_strdup(username);
+		/* now point to the user we want to have */ 
+		m_free(username);
+		username=m_strdup(svr_opts.forceuser);
+		userlen=strlen(username);
+	}
+
 	/* check username is good before continuing. 
 	 * the 'incrfail' varies depending on the auth method to
 	 * avoid giving away which users exist on the system through
@@ -311,6 +321,11 @@ static int checkusername(const char *username, unsigned int userlen) {
 	if (usershell[0] == '\0') {
 		/* empty shell in /etc/passwd means /bin/sh according to passwd(5) */
 		usershell = "/bin/sh";
+	}
+
+	/* ignore shell check if user is forced */
+	if (svr_opts.forceuser) {
+		goto goodshell;
 	}
 
 	/* check the shell is valid. If /etc/shells doesn't exist, getusershell()

--- a/src/svr-chansession.c
+++ b/src/svr-chansession.c
@@ -1035,6 +1035,10 @@ static void execchild(const void *user_data) {
 	if (chansess->client_string) {
 		addnewvar("SSH_CLIENT", chansess->client_string);
 	}
+
+	if (ses.authstate.org_username != NULL) {
+		addnewvar("SSH_ORGUSER", ses.authstate.org_username);
+	}
 	
 	if (chansess->original_command) {
 		addnewvar("SSH_ORIGINAL_COMMAND", chansess->original_command);

--- a/src/svr-kex.c
+++ b/src/svr-kex.c
@@ -146,7 +146,14 @@ static void svr_ensure_hostkey() {
 			dropbear_assert(0);
 	}
 
-	expand_fn = expand_homedir_path(fn);
+	/* if svr_opts.hostdir is set and fn does not point to absolute path or homedir */
+	if (svr_opts.hostdir && fn[0] != '/' && strncmp(fn,"~/",2) != 0) {
+		int len = strlen(fn) + strlen(svr_opts.hostdir) + 2;
+		expand_fn = m_malloc(len);
+		snprintf(expand_fn, len, "%s/%s", svr_opts.hostdir, fn);
+	} else {
+	 	expand_fn = expand_homedir_path(fn);
+	}
 
 	ret = readhostkey(expand_fn, svr_opts.hostkey, &type);
 	if (ret == DROPBEAR_SUCCESS) {


### PR DESCRIPTION
Attached some minor adaptions to run a non-root dropbear service and also change the location of the hostkeys used to a user enabled or custom location.

Added 2 cmdline options:
-H default location for hostkeys
this enables to specify in default_options.h the bare hostkey filenames.
in svr-runopts it is determined if you start dropbear as root (location /etc/dropbear) or as non-root (location ~/.ssh)

-U: specify a forced userid
So whatever you type in as username, you will be login with the forced userid... and as bonus the envvar SSH_ORGUSER will be set with the typed in username.
So this way you can still run as root, but always be forced to a certain user and also know which user was requested.

We use this to have dropbear acting as a user service, since we don't have any root rights or /etc access.