### PR TITLE
Fix build when htole64 and related macros are defined in endian.h or sys/endian.h

### DIFF
--- a/configure
+++ b/configure
@@ -7620,7 +7620,15 @@ then :
 
 fi
 
-ac_fn_check_decl "$LINENO" "htole64" "ac_cv_have_decl_htole64" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
+ac_fn_check_decl "$LINENO" "htole64" "ac_cv_have_decl_htole64" "
+	#ifdef HAVE_ENDIAN_H
+		#include <endian.h>
+	#endif
+	#ifdef HAVE_SYS_ENDIAN_H
+		#include <sys/endian.h>
+	#endif
+
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
 if test "x$ac_cv_have_decl_htole64" = xyes
 then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -553,7 +553,14 @@ AC_CHECK_FUNCS(htole64)
 AC_CHECK_DECL(htole64,
 	[
 	AC_DEFINE(HAVE_DECL_HTOLE64,1,htole64 is a macro)
-	],,)
+	],,[
+	#ifdef HAVE_ENDIAN_H
+		#include <endian.h>
+	#endif
+	#ifdef HAVE_SYS_ENDIAN_H
+		#include <sys/endian.h>
+	#endif
+	])
 
 # POSIX monotonic time
 AC_CHECK_FUNCS(clock_gettime)


### PR DESCRIPTION
Currently, if `htole64` is available on a platform as a macro in `endian.h` or `sys/endian.h` the `AC_CHECK_DECL` test does not detect them as they are not included in it.  As those two headers are however included in the build this causes the declarations of the compat functions to be mangled by the undetected macros and fail to compile.

Resolve this by passing conditional includes of `endian.h` and `sys/endian.h` to the includes parameter of the `AC_CHECK_DECL` macro so that the `htole64` macro is detected correctly.

(I found this when attempting to cross compile 2025.87 for Android where `htole64` is a macro defined in `sys/endian.h`.)