### PR TITLE
Test for static_assert

### DIFF
--- a/configure
+++ b/configure
@@ -8729,6 +8729,84 @@ printf "%s\n" "$as_me: Not checking for /dev/ptc & /dev/pts since we're cross-co
 	fi
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for static_assert" >&5
+printf %s "checking for static_assert... " >&6; }
+if test ${ac_cv_have_static_assert+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <assert.h>
+
+int
+main (void)
+{
+ static_assert(1 == 1, "bad ram?");
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+   ac_cv_have_static_assert="yes"
+else $as_nop
+   ac_cv_have_static_assert="no"
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_have_static_assert" >&5
+printf "%s\n" "$ac_cv_have_static_assert" >&6; }
+if test "$ac_cv_have_static_assert" = "yes" ; then
+
+printf "%s\n" "#define HAVE_STATIC_ASSERT 1" >>confdefs.h
+
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for _Static_assert" >&5
+printf %s "checking for _Static_assert... " >&6; }
+if test ${ac_cv_have_underscore_static_assert+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <assert.h>
+
+int
+main (void)
+{
+ _Static_assert(1 == 1, "cosmic rays?");
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+   ac_cv_have_underscore_static_assert="yes"
+else $as_nop
+   ac_cv_have_underscore_static_assert="no"
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_have_underscore_static_assert" >&5
+printf "%s\n" "$ac_cv_have_underscore_static_assert" >&6; }
+if test "$ac_cv_have_underscore_static_assert" = "yes" ; then
+
+printf "%s\n" "#define HAVE_UNDERSCORE_STATIC_ASSERT 1" >>confdefs.h
+
+fi
+
 
 
 if test $BUNDLED_LIBTOM = 1 ; then

--- a/configure.ac
+++ b/configure.ac
@@ -895,6 +895,32 @@ if test -z "$no_ptc_check" ; then
 	fi
 fi
 
+AC_CACHE_CHECK([for static_assert], ac_cv_have_static_assert, [
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <assert.h>
+		]],
+		[[ static_assert(1 == 1, "bad ram?"); ]])],
+		[ ac_cv_have_static_assert="yes" ],
+		[ ac_cv_have_static_assert="no" ]
+	)
+])
+if test "$ac_cv_have_static_assert" = "yes" ; then
+	AC_DEFINE(HAVE_STATIC_ASSERT,1,Have static_assert)
+fi
+
+AC_CACHE_CHECK([for _Static_assert], ac_cv_have_underscore_static_assert, [
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <assert.h>
+		]],
+		[[ _Static_assert(1 == 1, "cosmic rays?"); ]])],
+		[ ac_cv_have_underscore_static_assert="yes" ],
+		[ ac_cv_have_underscore_static_assert="no" ]
+	)
+])
+if test "$ac_cv_have_underscore_static_assert" = "yes" ; then
+	AC_DEFINE(HAVE_UNDERSCORE_STATIC_ASSERT,1,Have _Static_assert)
+fi
+
 AC_EXEEXT
 
 if test $BUNDLED_LIBTOM = 1 ; then

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -240,6 +240,9 @@
 /* Define to 1 if you have the <shadow.h> header file. */
 #undef HAVE_SHADOW_H
 
+/* Have static_assert */
+#undef HAVE_STATIC_ASSERT
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 
@@ -365,6 +368,9 @@
 
 /* Define to 1 if the system has the type `uint8_t'. */
 #undef HAVE_UINT8_T
+
+/* Have _Static_assert */
+#undef HAVE_UNDERSCORE_STATIC_ASSERT
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H

--- a/src/includes.h
+++ b/src/includes.h
@@ -56,6 +56,7 @@
 #include <dirent.h>
 #include <time.h>
 #include <setjmp.h>
+#include <assert.h>
 
 #ifdef HAVE_UTMP_H
 #include <utmp.h>
@@ -201,6 +202,18 @@ extern char** environ;
 # define UNUSED(x) /*@unused@*/ x 
 #else 
 # define UNUSED(x) x 
+#endif
+
+/* static_assert() is a keyword in c23, earlier libc often supports
+ * it as a macro in assert.h.
+ * _Static_assert() is a keyword supported since c11.
+ * If neither are available, do nothing */
+#ifndef HAVE_STATIC_ASSERT
+#ifdef HAVE_UNDERSCORE_STATIC_ASSERT
+#define static_assert(condition, message) _Static_assert(condition, message)
+#else
+#define static_assert(condition, message)
+#endif
 #endif
 
 #endif /* DROPBEAR_INCLUDES_H_ */


### PR DESCRIPTION
Older uClibc (< ~1.0.42) or older compilers don't support static_assert

Fixes #351