### PR TITLE
Fix type incompatibility in htole64 and htole32 with older GCC versions

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -288,7 +288,7 @@ uint64_t htole64(uint64_t inp) {
 		uint64_t v;
 		uint8_t bytes[8];
 	} out;
-	STORE64L(inp, &out.bytes);
+	STORE64L(inp, out.bytes);
 	return out.v;
 }
 
@@ -301,7 +301,7 @@ uint32_t htole32(uint32_t inp) {
 		uint32_t v;
 		uint8_t bytes[4];
 	} out;
-	STORE32L(inp, &out.bytes);
+	STORE32L(inp, out.bytes);
 	return out.v;
 }
 


### PR DESCRIPTION
**Problem**

Older versions of GCC (e.g., 4.6.4) report a type incompatibility error due to the way `&out.bytes` is passed to `STORE64L` and `STORE32L`.

```
src/compat.c: In function 'htole64':
src/compat.c:291:2: error: incompatible types when assigning to type 'uint8_t[8]' from type 'unsigned char'
```

 `out.bytes` is an array (`uint8_t[8]` for `htole64`, `uint8_t[4]` for `htole32`).
`&out.bytes` produces `uint8_t (*)[8]` (`uint8_t (*)[4]` for `htole32`), which does not match the expected `uint8_t*` parameter in `STORE64L` and `STORE32L`.
Newer compilers (e.g., GCC 4.8.5+) are more lenient, but older versions enforce strict type checking, leading to compilation errors.

**Solution**

Instead of passing `&out.bytes,` we pass `out.bytes` directly. This ensures proper type decay from an array to a pointer (`uint8_t*`), making the code compatible with both older and newer GCC versions.

**Changes**

Before:
```
STORE64L(inp, &out.bytes);
STORE32L(inp, &out.bytes);
```

After:
```
STORE64L(inp, out.bytes);
STORE32L(inp, out.bytes);
```

This change resolves the compilation issue while maintaining functional correctness.