### PR TITLE
Drop `which` from `configure.ac`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_PREREQ([2.59])
 AC_INIT
 
 # Record which revision is being built
-if test -s "`which hg`" && test -d "$srcdir/.hg"; then
+if test -s "`command -v hg`" && test -d "$srcdir/.hg"; then
 	hgrev=`hg id -i -R "$srcdir"`
 	AC_MSG_NOTICE([Source directory Mercurial base revision $hgrev])
 fi


### PR DESCRIPTION
There is an ongoing discussion about removing `which` and replacing it with POSIX compliant `command -v`.
See also: https://lwn.net/Articles/874049/

We are trying to remove it from the @system set.
See also: https://bugs.gentoo.org/955111
https://bugs.gentoo.org/646588#c0