### PR TITLE
Fix reference to distrooptions.h in default_options.h

### DIFF
--- a/src/default_options.h
+++ b/src/default_options.h
@@ -9,7 +9,7 @@ Local customisation should be added to localoptions.h which is
 used if it exists in the build directory. Options defined there will override
 any options in this file.
 
-Customisations will also be taken from src/distoptions.h if it exists.
+Customisations will also be taken from src/distrooptions.h if it exists.
 
 Options can also be defined with -DDROPBEAR_XXX=[0,1] in Makefile CFLAGS
 


### PR DESCRIPTION
The path for distribution customizations is src/distrooptions.h, not src/distoptions.h.

This minor typo was added in 454591d (Use src/distrooptions.h as another source, 2024-01-22).