### PR TITLE
Add vsock support

### DIFF
--- a/configure
+++ b/configure
@@ -6444,6 +6444,14 @@ then :
 
 fi
 
+ac_fn_c_check_header_compile "$LINENO" "linux/vm_sockets.h" "ac_cv_header_linux_vm_sockets_h" "#include <sys/socket.h>
+"
+if test "x$ac_cv_header_linux_vm_sockets_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_LINUX_VM_SOCKETS_H 1" >>confdefs.h
+
+fi
+
 
 # Checks for typedefs, structures, and compiler characteristics.
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for an ANSI C-conforming const" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,7 @@ AC_CHECK_HEADERS([netinet/in.h netinet/tcp.h \
 	utmpx.h lastlog.h paths.h util.h netdb.h security/pam_appl.h \
 	pam/pam_appl.h netinet/in_systm.h sys/uio.h linux/pkt_sched.h \
 	sys/random.h sys/prctl.h])
+AC_CHECK_HEADERS([linux/vm_sockets.h], , , [#include <sys/socket.h>])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -174,6 +174,9 @@
 /* Define to 1 if you have the <linux/pkt_sched.h> header file. */
 #undef HAVE_LINUX_PKT_SCHED_H
 
+/* Define to 1 if you have the <linux/vm_sockets.h> header file. */
+#undef HAVE_LINUX_VM_SOCKETS_H
+
 /* Have login() function */
 #undef HAVE_LOGIN
 

--- a/src/includes.h
+++ b/src/includes.h
@@ -180,6 +180,10 @@ typedef u_int32_t uint32_t;
 #include <linux/pkt_sched.h>
 #endif
 
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+#include <linux/vm_sockets.h>
+#endif
+
 #if DROPBEAR_PLUGIN
 #include <dlfcn.h>
 #endif

--- a/src/svr-tcpfwd.c
+++ b/src/svr-tcpfwd.c
@@ -286,6 +286,9 @@ static int newtcpdirect(struct Channel * channel) {
 	origport = buf_getint(ses.payload);
 
 	/* best be sure */
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+	if (strstr(orighost, "%vsock") != NULL) {} else
+#endif
 	if (origport > 65535 || destport > 65535) {
 		TRACE(("leave newtcpdirect: port > 65535"))
 		goto out;

--- a/src/tcp-accept.c
+++ b/src/tcp-accept.c
@@ -60,6 +60,13 @@ static void tcp_acceptor(const struct Listener *listener, int sock) {
 		return;
 	}
 
+#ifdef HAVE_LINUX_VM_SOCKETS_H
+	if (sa.ss_family == AF_VSOCK) {
+		struct sockaddr_vm *vsockaddr = (void *)&sa;
+		snprintf(ipstring, NI_MAXHOST - 1, "%u%%vsock", vsockaddr->svm_cid);
+		snprintf(portstring, NI_MAXSERV - 1, "%u", vsockaddr->svm_port);
+	} else
+#endif
 	if (getnameinfo((struct sockaddr*)&sa, len, ipstring, sizeof(ipstring),
 				portstring, sizeof(portstring), 
 				NI_NUMERICHOST | NI_NUMERICSERV) != 0) {


### PR DESCRIPTION
We were thinking that having vsock support in dropbear could be useful when having VMs with dropbear. We are considering to use this for OpenWRT/Gluon testing specifically as we could just add a vsock listener by default and then use it in the environment. While on real HW, it would just fail to listen on that socket.

The approach here is to accept AF_VSOCK anywhere where IP sockets are also allowed. Not sure that is a great idea. I am happy to change the approach.

I have tested that listening on the server, connecting the client and port forwarding work.

Examples (just running on the host):
```
./dropbear -p localhost:22 -p %vsock:22 -E -F -R
./dbclient 1%vsock -p 22 -L %vsock:80:localhost:80
```