### PR TITLE
fix: ignore -g -s when passwords arent enabled

### DIFF
--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -323,6 +323,10 @@ void svr_getopts(int argc, char ** argv) {
 				case 't':
 					svr_opts.multiauthmethod = 1;
 					break;
+#else
+				case 's':
+				case 'g':
+					break;
 #endif
 				case 'h':
 					printhelp(argv[0]);


### PR DESCRIPTION
I ran into this issue, after libcrypt.so is not available in a newer root filesystem.
dropbear was then erroring out because passwords where explicitly disabled before. 

If not built with password support, those options should just be ignored.

Closes: #388