### PR TITLE
Update configure.ac minimum to 2.70

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 # of the platform checks have been taken straight from OpenSSH's configure.ac
 # Huge thanks to them for dealing with the horrible platform-specifics :)
 
-AC_PREREQ([2.59])
+AC_PREREQ([2.70])
 AC_INIT
 
 ORIGCFLAGS="$CFLAGS"


### PR DESCRIPTION
Previous versions don't search src/ for install.sh as a AC_CONFIG_AUX_DIR path.

Fixes #334