### PR TITLE
Disallow server signals when not appropriate

### DIFF
--- a/src/svr-chansession.c
+++ b/src/svr-chansession.c
@@ -443,6 +443,11 @@ static int sessionsignal(const struct ChanSess *chansess) {
 		return DROPBEAR_FAILURE;
 	}
 
+	if (DROPBEAR_SVR_MULTIUSER && !DROPBEAR_SVR_DROP_PRIVS) {
+		TRACE(("disallow signal without drop privs"));
+		return DROPBEAR_FAILURE;
+	}
+
 	signame = buf_getstring(ses.payload, NULL);
 
 	for (i = 0; signames[i].name != NULL; i++) {


### PR DESCRIPTION
Don't allow signals when running privileged, or when there is a forced command