### PR TITLE
Interpret known_hosts a little more like OpenSSH does

### DIFF
--- a/src/cli-kex.c
+++ b/src/cli-kex.c
@@ -368,11 +368,15 @@ static void checkhostkey(const unsigned char* keyblob, unsigned int keybloblen) 
 
 		/* Compare hostnames */
 		if (strncmp(cli_opts.remotehost, (const char *) buf_getptr(line, hostlen),
-					hostlen) != 0) {
+					hostlen) == 0) {
+			/* We have matched the full cli hostname */
+			buf_incrpos(line, hostlen);
+		} else if (buf_getbyte(line) == '*') {
+			/* We have matched a * wildcard */
+		} else {
 			continue;
 		}
 
-		buf_incrpos(line, hostlen);
 		if (buf_getbyte(line) != ' ') {
 			/* there wasn't a space after the hostname, something dodgy */
 			TRACE(("missing space afte matching hostname"))
@@ -400,16 +404,6 @@ static void checkhostkey(const unsigned char* keyblob, unsigned int keybloblen) 
 			goto out;
 		}
 
-		/* The keys didn't match. eep. Note that we're "leaking"
-		   the fingerprint strings here, but we're exiting anyway */
-		dropbear_exit("\n\n%s host key mismatch for %s !\n"
-					"Fingerprint is %s\n"
-					"Expected %s\n"
-					"If you know that the host key is correct you can\nremove the bad entry from ~/.ssh/known_hosts", 
-					algoname,
-					cli_opts.remotehost,
-					sign_key_fingerprint(keyblob, keybloblen),
-					fingerprint ? fingerprint : "UNKNOWN");
 	} while (1); /* keep going 'til something happens */
 
 	/* Key doesn't exist yet */


### PR DESCRIPTION
- Allow * wildcard as as an alternative to a full hostname or ip address in known_hosts
- Ignore lines which match the hostname or ip address and key type, but where the public key itself does not match.  This is the behaviour of OpenSSH, and allows for ignoring old or badly formed host keys.

Removing the former dropbear_exit() notification makes known_hosts behave more like OpenSSH, namely "When performing host authentication, authentication is accepted if **any** matching line has the proper key" from [OpenSSH known_hosts file](https://man.openbsd.org/sshd.8#SSH_KNOWN_HOSTS_FILE_FORMAT)

The change is tested against known_hosts which contain fragmentary lines, old lines and wildcards. The change makes the known_hosts file a little more robust to mistakes.  It reduces the size of dbclient text segment by about 200 bytes on ARM64 Linux.  

Wildcard for hostname is something I want to use for some of my work. In the future it would be easy to also allow wildcards to the left of any hostname, which I can add if needed, but decided to keep this first contribution super simple.