### PR TITLE
Add S < L check to curve25519

### DIFF
--- a/src/curve25519.c
+++ b/src/curve25519.c
@@ -54,7 +54,9 @@ static const gf
 #if DROPBEAR_SIGNKEY_VERIFY
 static const gf
   D = {0x78a3, 0x1359, 0x4dca, 0x75eb, 0xd8ab, 0x4141, 0x0a4d, 0x0070, 0xe898, 0x7779, 0x4079, 0x8cc7, 0xfe73, 0x2b6f, 0x6cee, 0x5203},
-  I = {0xa0b0, 0x4a0e, 0x1b27, 0xc4ee, 0xe478, 0xad2f, 0x1806, 0x2f43, 0xd7a7, 0x3dfb, 0x0099, 0x2b4d, 0xdf0b, 0x4fc1, 0x2480, 0x2b83};
+  I = {0xa0b0, 0x4a0e, 0x1b27, 0xc4ee, 0xe478, 0xad2f, 0x1806, 0x2f43, 0xd7a7, 0x3dfb, 0x0099, 0x2b4d, 0xdf0b, 0x4fc1, 0x2480, 0x2b83},
+  /* p = 2^255 - 19 */
+  field_prime = {0xffed, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0x7fff};
 #endif /* DROPBEAR_SIGNKEY_VERIFY */
 #endif /* DROPBEAR_ED25519 */
 
@@ -442,11 +444,33 @@ static int s_lt_l(const u8 *s) {
   return -1;
 }
 
+/* Return 0 if y < p, -1 otherwise.
+ * field prime p = 2^255 - 19
+ * Only used during verify so timing side-channel is OK */
+static int y_lt_p(const gf y) {
+  int i;
+  for (i = 15; i >= 0; i--) {
+    if (y[i] < field_prime[i]) {
+      return 0;
+    }
+    if (y[i] > field_prime[i]) {
+      return -1;
+    }
+  }
+  return -1;
+}
+
 static int unpackneg(gf r[4],const u8 p[32])
 {
   gf t, chk, num, den, den2, den4, den6;
   set25519(r[2],gf1);
   unpack25519(r[1],p);
+
+  /* Check that pubkey y < 2^255 - 19 */
+  if (y_lt_p(r[1])) {
+    return -1;
+  }
+
   S(num,r[1]);
   M(den,num,D);
   Z(num,num,r[2]);

--- a/src/curve25519.c
+++ b/src/curve25519.c
@@ -426,6 +426,22 @@ void dropbear_ed25519_sign(const u8 *m,u32 mlen,u8 *s,u32 *slen,const u8 *sk, co
 }
 
 #if DROPBEAR_SIGNKEY_VERIFY
+
+/* Return 0 if S < L, -1 otherwise.
+ * Only used during verify so timing side-channel is OK */
+static int s_lt_l(const u8 *s) {
+  int i;
+  for (i = 31; i >= 0; i--) {
+    if (s[i] < L[i]) {
+      return 0;
+    }
+    if (s[i] > L[i]) {
+      return -1;
+    }
+  }
+  return -1;
+}
+
 static int unpackneg(gf r[4],const u8 p[32])
 {
   gf t, chk, num, den, den2, den4, den6;
@@ -469,6 +485,10 @@ int dropbear_ed25519_verify(const u8 *m,u32 mlen,const u8 *s,u32 slen,const u8 *
   gf p[4],q[4];
 
   if (slen < 64) return -1;
+
+  if (s_lt_l(s + 32) == -1) {
+    return -1;
+  }
 
   if (unpackneg(q,pk)) return -1;
 


### PR DESCRIPTION
This is required by rfc8032 and avoids signature malleability (s' = s+L would also be accepted). That does not have any security impact on the way it is used in SSH protocol.

The check was not present in original tweetnacl.

Thanks to YuJie Zhu for the report.

Fixes #406