### PR TITLE
Add new parameter -M for max. duration

### DIFF
--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -84,6 +84,7 @@ static void printhelp() {
 					"-W <receive_window_buffer> (default %d, larger may be faster, max 10MB)\n"
 					"-K <keepalive>  (0 is never, default %d)\n"
 					"-I <idle_timeout>  (0 is never, default %d)\n"
+					"-M <max_duration>  (0 is off, default %d, in seconds)\n"
 					"-z    disable QoS\n"
 #if DROPBEAR_CLI_NETCAT
 					"-B <endhost:endport> Netcat-alike forwarding\n"
@@ -104,7 +105,8 @@ static void printhelp() {
 #if DROPBEAR_CLI_PUBKEY_AUTH
 					DROPBEAR_DEFAULT_CLI_AUTHKEY,
 #endif
-					DEFAULT_RECV_WINDOW, DEFAULT_KEEPALIVE, DEFAULT_IDLE_TIMEOUT);
+					DEFAULT_RECV_WINDOW, DEFAULT_KEEPALIVE, DEFAULT_IDLE_TIMEOUT,
+					DEFAULT_MAX_DURATION);
 
 }
 
@@ -132,6 +134,7 @@ void cli_getopts(int argc, char ** argv) {
 
 	const char* recv_window_arg = NULL;
 	const char* idle_timeout_arg = NULL;
+	const char* max_duration_arg = NULL;
 	const char *host_arg = NULL;
 	const char *proxycmd_arg = NULL;
 	const char *remoteport_arg = NULL;
@@ -198,6 +201,7 @@ void cli_getopts(int argc, char ** argv) {
 	opts.recv_window = DEFAULT_RECV_WINDOW;
 	opts.keepalive_secs = DEFAULT_KEEPALIVE;
 	opts.idle_timeout_secs = DEFAULT_IDLE_TIMEOUT;
+	opts.max_duration_secs = DEFAULT_MAX_DURATION;
 
 	fill_own_user();
 
@@ -298,6 +302,9 @@ void cli_getopts(int argc, char ** argv) {
 					break;
 				case 'I':
 					next = &idle_timeout_arg;
+					break;
+				case 'M':
+					next = &max_duration_arg;
 					break;
 #if DROPBEAR_CLI_AGENTFWD
 				case 'A':
@@ -505,6 +512,14 @@ void cli_getopts(int argc, char ** argv) {
 			dropbear_exit("Bad idle_timeout '%s'", idle_timeout_arg);
 		}
 		opts.idle_timeout_secs = val;
+	}
+
+	if (max_duration_arg) {
+		unsigned int val;
+		if (m_str_to_uint(max_duration_arg, &val) == DROPBEAR_FAILURE) {
+			dropbear_exit("Bad max_duration '%s'", max_duration_arg);
+		}
+		opts.max_duration_secs = val;
 	}
 
 #if DROPBEAR_CLI_NETCAT

--- a/src/common-session.c
+++ b/src/common-session.c
@@ -592,6 +592,11 @@ static void checktimeouts() {
 			&& elapsed(now, ses.last_packet_time_idle) >= opts.idle_timeout_secs) {
 		dropbear_close("Idle timeout");
 	}
+
+	if (opts.max_duration_secs > 0
+			&& elapsed(now, ses.connect_time) >= opts.max_duration_secs) {
+		dropbear_close("Max duration reached");
+	}
 }
 
 static void update_timeout(long limit, time_t now, time_t last_event, long * timeout) {
@@ -630,6 +635,9 @@ static long select_timeout() {
 	}
 
 	update_timeout(opts.idle_timeout_secs, now, ses.last_packet_time_idle,
+		&timeout);
+
+	update_timeout(opts.max_duration_secs, now, ses.connect_time,
 		&timeout);
 
 	/* clamp negative timeouts to zero - event has already triggered */

--- a/src/common-session.c
+++ b/src/common-session.c
@@ -547,7 +547,7 @@ static void checktimeouts() {
 	time_t now;
 	now = monotonic_now();
 
-	if (IS_DROPBEAR_SERVER && ses.connect_time != 0
+	if (IS_DROPBEAR_SERVER && ses.authstate.authdone != 1
 		&& elapsed(now, ses.connect_time) >= AUTH_TIMEOUT) {
 			dropbear_close("Timeout before auth");
 	}

--- a/src/default_options.h
+++ b/src/default_options.h
@@ -389,6 +389,10 @@ for runtime configuration please mail the Dropbear list */
 be overridden at runtime with -I. 0 disables idle timeouts */
 #define DEFAULT_IDLE_TIMEOUT 0
 
+/* Disconnect after MAX_DURATION seconds. This can be overridden at
+runtime with -M. 0 disables this feature. */
+#define DEFAULT_MAX_DURATION 0
+
 /* The default path. This will often get replaced by the shell */
 #define DEFAULT_PATH "/usr/bin:/bin"
 #define DEFAULT_ROOT_PATH "/usr/sbin:/usr/bin:/sbin:/bin"

--- a/src/runopts.h
+++ b/src/runopts.h
@@ -41,6 +41,7 @@ typedef struct runopts {
 	unsigned int recv_window;
 	long keepalive_secs; /* Time between sending keepalives. 0 is off */
 	long idle_timeout_secs; /* Exit if no traffic is sent/received in this time */
+	long max_duration_secs; /* Exit after this time */
 	int usingsyslog;
 
 #ifndef DISABLE_ZLIB

--- a/src/svr-auth.c
+++ b/src/svr-auth.c
@@ -461,11 +461,7 @@ void send_msg_userauth_success() {
 #if DROPBEAR_SVR_DROP_PRIVS
 	/* Drop privileges as soon as authentication has happened. */
 	svr_switch_user();
-#endif
-	ses.connect_time = 0;
 
-
-#if DROPBEAR_SVR_DROP_PRIVS
 	/* If running as the user, we can rely on the OS
 	 * to limit allowed ports */
 	ses.allowprivport = 1;

--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -112,6 +112,7 @@ static void printhelp(const char * progname) {
 					"-W <receive_window_buffer> (default %d, larger may be faster, max 10MB)\n"
 					"-K <keepalive>  (0 is never, default %d, in seconds)\n"
 					"-I <idle_timeout>  (0 is never, default %d, in seconds)\n"
+					"-M <max_duration>  (0 is off, default %d, in seconds)\n"
 					"-z    disable QoS\n"
 #if DROPBEAR_PLUGIN
                                         "-A <authplugin>[,<options>]\n"
@@ -136,7 +137,8 @@ static void printhelp(const char * progname) {
 #endif
 					MAX_AUTH_TRIES,
 					DROPBEAR_MAX_PORTS, DROPBEAR_DEFPORT, DROPBEAR_PIDFILE,
-					DEFAULT_RECV_WINDOW, DEFAULT_KEEPALIVE, DEFAULT_IDLE_TIMEOUT);
+					DEFAULT_RECV_WINDOW, DEFAULT_KEEPALIVE, DEFAULT_IDLE_TIMEOUT,
+					DEFAULT_MAX_DURATION);
 }
 
 void svr_getopts(int argc, char ** argv) {
@@ -147,6 +149,7 @@ void svr_getopts(int argc, char ** argv) {
 	char* recv_window_arg = NULL;
 	char* keepalive_arg = NULL;
 	char* idle_timeout_arg = NULL;
+	char* max_duration_arg = NULL;
 	char* maxauthtries_arg = NULL;
 	char* reexec_fd_arg = NULL;
 	char* keyfile = NULL;
@@ -207,7 +210,8 @@ void svr_getopts(int argc, char ** argv) {
 	opts.recv_window = DEFAULT_RECV_WINDOW;
 	opts.keepalive_secs = DEFAULT_KEEPALIVE;
 	opts.idle_timeout_secs = DEFAULT_IDLE_TIMEOUT;
-	
+	opts.max_duration_secs = DEFAULT_MAX_DURATION;
+
 #if DROPBEAR_SVR_REMOTETCPFWD
 	opts.listen_fwd_all = 0;
 #endif
@@ -315,6 +319,9 @@ void svr_getopts(int argc, char ** argv) {
 					break;
 				case 'I':
 					next = &idle_timeout_arg;
+					break;
+				case 'M':
+					next = &max_duration_arg;
 					break;
 				case 'T':
 					next = &maxauthtries_arg;
@@ -447,6 +454,14 @@ void svr_getopts(int argc, char ** argv) {
 			dropbear_exit("Bad idle_timeout '%s'", idle_timeout_arg);
 		}
 		opts.idle_timeout_secs = val;
+	}
+
+	if (max_duration_arg) {
+		unsigned int val;
+		if (m_str_to_uint(max_duration_arg, &val) == DROPBEAR_FAILURE) {
+			dropbear_exit("Bad max_duration '%s'", max_duration_arg);
+		}
+		opts.max_duration_secs = val;
 	}
 
 	if (svr_opts.forced_command) {


### PR DESCRIPTION
Some technical guidelines (e.g., TR-03148) and cybersecurity baselines
require a hard maximum connection duration / session timeout for remote
connections. Therefore, a parameter is hereby introduced that can be
used to configure the maximum connection duration. The default value is
0 (disabled).