### PR TITLE
Fix cancelling server TCP listeners

### DIFF
--- a/src/listener.c
+++ b/src/listener.c
@@ -136,9 +136,9 @@ struct Listener * get_listener(enum ListenerType type, const void* typedata,
 		int (*match)(const void*, const void*)) {
 
 	unsigned int i;
-	struct Listener* listener;
 
-	for (i = 0, listener = ses.listeners[i]; i < ses.listensize; i++) {
+	for (i = 0; i < ses.listensize; i++) {
+		struct Listener* listener = ses.listeners[i];
 		if (listener && listener->type == type
 				&& match(typedata, listener->typedata)) {
 			return listener;

--- a/src/listener.c
+++ b/src/listener.c
@@ -77,7 +77,7 @@ void handle_listeners(const fd_set * readfds) {
 /* acceptor(int fd, void* typedata) is a function to accept connections, 
  * cleanup(void* typedata) happens when cleaning up */
 struct Listener* new_listener(const int socks[], unsigned int nsocks,
-		int type, void* typedata, 
+		enum ListenerType type, void* typedata,
 		void (*acceptor)(const struct Listener* listener, int sock),
 		void (*cleanup)(const struct Listener*)) {
 
@@ -132,7 +132,7 @@ struct Listener* new_listener(const int socks[], unsigned int nsocks,
 
 /* Return the first listener which matches the type-specific comparison
  * function. Particularly needed for global requests, like tcp */
-struct Listener * get_listener(int type, const void* typedata,
+struct Listener * get_listener(enum ListenerType type, const void* typedata,
 		int (*match)(const void*, const void*)) {
 
 	unsigned int i;

--- a/src/listener.h
+++ b/src/listener.h
@@ -28,6 +28,13 @@
 #define MAX_LISTENERS 20
 #define LISTENER_EXTEND_SIZE 1
 
+/* X11 and Agent use default. TCP has a specific type since
+   it can be cancelled, so get_listener() needs to match it. */
+enum ListenerType {
+	LISTENER_TYPE_DEFAULT,
+	LISTENER_TYPE_TCPFORWARDED,
+};
+
 struct Listener {
 
 	int socks[DROPBEAR_MAX_SOCKS];
@@ -38,9 +45,7 @@ struct Listener {
 	void (*acceptor)(const struct Listener*, int sock);
 	void (*cleanup)(const struct Listener*);
 
-	int type; /* CHANNEL_ID_X11, CHANNEL_ID_AGENT, 
-				 CHANNEL_ID_TCPDIRECT (for clients),
-				 CHANNEL_ID_TCPFORWARDED (for servers) */
+	enum ListenerType type;
 
 	void *typedata;
 
@@ -51,11 +56,11 @@ void handle_listeners(const fd_set * readfds);
 void set_listener_fds(fd_set * readfds);
 
 struct Listener* new_listener(const int socks[], unsigned int nsocks,
-		int type, void* typedata, 
+		enum ListenerType type, void* typedata,
 		void (*acceptor)(const struct Listener* listener, int sock),
 		void (*cleanup)(const struct Listener*));
 
-struct Listener * get_listener(int type, const void* typedata,
+struct Listener * get_listener(enum ListenerType type, const void* typedata,
 		int (*match)(const void*, const void*));
 
 void remove_listener(struct Listener* listener);

--- a/src/svr-agentfwd.c
+++ b/src/svr-agentfwd.c
@@ -80,8 +80,9 @@ int svr_agentreq(struct ChanSess * chansess) {
 	setnonblocking(fd);
 
 	/* pass if off to listener */
-	chansess->agentlistener = new_listener( &fd, 1, 0, chansess, 
-								agentaccept, NULL);
+	chansess->agentlistener = new_listener( &fd, 1,
+		LISTENER_TYPE_DEFAULT, chansess,
+		agentaccept, NULL);
 
 	if (chansess->agentlistener == NULL) {
 		goto fail;

--- a/src/svr-tcpfwd.c
+++ b/src/svr-tcpfwd.c
@@ -159,7 +159,7 @@ static int svr_cancelremotetcp() {
 	tcpinfo.sendport = 0;
 	tcpinfo.listenaddr = bindaddr;
 	tcpinfo.listenport = port;
-	listener = get_listener(CHANNEL_ID_TCPFORWARDED, &tcpinfo, matchtcp);
+	listener = get_listener(LISTENER_TYPE_TCPFORWARDED, &tcpinfo, matchtcp);
 	if (listener) {
 		remove_listener( listener );
 		ret = DROPBEAR_SUCCESS;

--- a/src/svr-tcpfwd.c
+++ b/src/svr-tcpfwd.c
@@ -132,14 +132,13 @@ static int matchtcp(const void* typedata1, const void* typedata2) {
 	const struct TCPListener *info2 = (struct TCPListener*)typedata2;
 
 	return (info1->listenport == info2->listenport)
-			&& (info1->chantype == info2->chantype)
-			&& (strcmp(info1->listenaddr, info2->listenaddr) == 0);
+			&& (strcmp(info1->request_listenaddr, info2->request_listenaddr) == 0);
 }
 
 static int svr_cancelremotetcp() {
 
 	int ret = DROPBEAR_FAILURE;
-	char * bindaddr = NULL;
+	char * request_addr = NULL;
 	unsigned int addrlen;
 	unsigned int port;
 	struct Listener * listener = NULL;
@@ -147,7 +146,7 @@ static int svr_cancelremotetcp() {
 
 	TRACE(("enter cancelremotetcp"))
 
-	bindaddr = buf_getstring(ses.payload, &addrlen);
+	request_addr = buf_getstring(ses.payload, &addrlen);
 	if (addrlen > MAX_HOST_LEN) {
 		TRACE(("addr len too long: %d", addrlen))
 		goto out;
@@ -155,18 +154,17 @@ static int svr_cancelremotetcp() {
 
 	port = buf_getint(ses.payload);
 
-	tcpinfo.sendaddr = NULL;
-	tcpinfo.sendport = 0;
-	tcpinfo.listenaddr = bindaddr;
+	memset(&tcpinfo, 0x0, sizeof(tcpinfo));
+	tcpinfo.request_listenaddr = request_addr;
 	tcpinfo.listenport = port;
 	listener = get_listener(LISTENER_TYPE_TCPFORWARDED, &tcpinfo, matchtcp);
 	if (listener) {
-		remove_listener( listener );
+		remove_listener(listener);
 		ret = DROPBEAR_SUCCESS;
 	}
 
 out:
-	m_free(bindaddr);
+	m_free(request_addr);
 	TRACE(("leave cancelremotetcp"))
 	return ret;
 }

--- a/src/svr-x11fwd.c
+++ b/src/svr-x11fwd.c
@@ -108,7 +108,8 @@ int x11req(struct ChanSess * chansess) {
 	/* listener code will handle the socket now.
 	 * No cleanup handler needed, since listener_remove only happens
 	 * from our cleanup anyway */
-	chansess->x11listener = new_listener( &fd, 1, 0, chansess, x11accept, NULL);
+	chansess->x11listener = new_listener( &fd, 1, LISTENER_TYPE_DEFAULT,
+		chansess, x11accept, NULL);
 	if (chansess->x11listener == NULL) {
 		goto fail;
 	}

--- a/src/tcp-accept.c
+++ b/src/tcp-accept.c
@@ -127,7 +127,7 @@ int listen_tcpfwd(struct TCPListener* tcpinfo, struct Listener **ret_listener) {
 	m_free(errstring);
 	
 	/* new_listener will close the socks if it fails */
-	listener = new_listener(socks, nsocks, CHANNEL_ID_TCPFORWARDED, tcpinfo, 
+	listener = new_listener(socks, nsocks, LISTENER_TYPE_TCPFORWARDED, tcpinfo,
 			tcp_acceptor, cleanup_tcp);
 
 	if (listener == NULL) {

--- a/src/tcpfwd.h
+++ b/src/tcpfwd.h
@@ -75,7 +75,4 @@ void cli_recv_msg_request_failure(void);
 /* Common */
 int listen_tcpfwd(struct TCPListener* tcpinfo, struct Listener **ret_listener);
 
-/* A random identifier */
-#define CHANNEL_ID_TCPFORWARDED 0x43612c67
-
 #endif

--- a/test/test_canceltcplisten.py
+++ b/test/test_canceltcplisten.py
@@ -1,0 +1,51 @@
+"""
+Tests cancel-tcpip-forward
+"""
+from test_dropbear import *
+
+import asyncssh
+import asyncio
+import socket
+import errno
+import random
+
+async def run(addr, port):
+    async with asyncssh.connect(addr, port = port) as conn:
+
+        fwds = []
+        COUNT=4
+
+        def connect(host, port):
+            print(f"connection from {host}:{port}")
+
+        for x in range(COUNT):
+            server = await conn.start_server(connect, '', 0,
+                                     encoding='utf-8')
+            print(f"opened fwd {server} port {server.get_port()}")
+            fwds.append(server)
+
+        # Check that they can be connected
+        for f in fwds:
+            c = socket.create_connection(("localhost", f.get_port()))
+
+        # In case list ordering is important
+        random.shuffle(fwds)
+
+        for f in fwds:
+            print(f"close fwd {f}")
+            f.close()
+            await f.wait_closed()
+
+            # Check it's closed
+            try:
+                c = socket.create_connection(("localhost", f.get_port()))
+                assert False, f"Expected {f} port {f.get_port()} to be closed"
+            except OSError as e:
+                assert e.errno == errno.ECONNREFUSED
+
+def test_canceltcplisten(request, dropbear):
+    opt = request.config.option
+    host = opt.remote or LOCALADDR
+    port = int(opt.port)
+
+    asyncio.run(run(host, port))

--- a/test/test_dropbear.py
+++ b/test/test_dropbear.py
@@ -38,8 +38,15 @@ def dropbear(request):
 	yield p
 	p.terminate()
 	print("Terminated dropbear. Flushing output:")
-	for l in p.stderr:
-		print(l.rstrip())
+	lines = [l.rstrip() for l in p.stderr]
+	for l in lines:
+		print(l)
+
+	for l in lines:
+		# Crude segfault detection to catch segfaults in server
+		# child processes.
+		assert "Aiee, segfault" not in l
+
 	print("Done")
 
 def dbclient(request, *args, **kwargs):


### PR DESCRIPTION
There are three bugs involved here.

get_listener() only tested the first element in the list rather than
iterating.  This was incorrect when first written in
https://github.com/mkj/dropbear/commit/444dbb5364798925a3cacddba7b1bb3041e41a23 ("- Reworked non-channel fd handling to listener.c - More channel cleaning up")

tcpinfo.chantype isn't initialised in svr_cancelremotetcp(), so
matchtcp() never succeeded. The chantype comparison is unnecessary
(LISTENER_TYPE_TCPFORWARDED has already been checked), so remove it.

matchtcp() was comparing with listenaddr, but that will be NULL
when listening on localhost, logic in svr_remotetcpreq().
This codepath previously couldn't be reached due to the chantype test.
That regressed in https://github.com/mkj/dropbear/commit/1984aabc950904a9717735ae82b0bbf7d89d3478 ("Server shouldn't return "localhost" in response to -R forward connections if that wasn't what the client requested.")

A testcase is added.

Fixes https://github.com/mkj/dropbear/issues/412, fixes https://github.com/mkj/dropbear/issues/413