### PR TITLE
scp: fix recursive overwrite check

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -586,11 +586,14 @@ tolocal(int argc, char **argv)
 		}
 
 		char *dest = *(argv + argc - 1);
-		if (!(access(dest, F_OK) == 0 && errno == ENOENT)) {
-			/* paths sent from the server in recursive mode aren't adequately
-			 * checked that they match the requested files, so disallow this */
-			fprintf(stderr, "-r destination \"%s\" must not already exist\n", dest);
-			exit(1);
+		if (iamrecursive) {
+			/* Destination must not exist */
+			if (!(access(dest, F_OK) == -1 && errno == ENOENT)) {
+				/* paths sent from the server in recursive mode aren't adequately
+				 * checked that they match the requested files, so disallow this */
+				fprintf(stderr, "-r destination \"%s\" must not already exist\n", dest);
+				exit(1);
+			}
 		}
 
 		host = cleanhostname(host);


### PR DESCRIPTION
Non-recursive transfers were incorrectly disallowed to an existing
destination.

In addition, the destination check logic was wrong.

Fixes: 61bd0e3 ("scp: Disallow -r to an existing directory")