### PR TITLE
Disable compression by default

### DIFF
--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -962,9 +962,14 @@ static int match_extendedopt(const char** strptr, const char *optname) {
 }
 
 static int parse_flag_value(const char *value) {
-	if (strcmp(value, "yes") == 0 || strcmp(value, "true") == 0) {
+	if (strcmp(value, "yes") == 0
+		|| strcmp(value, "y") == 0
+		|| strcmp(value, "true") == 0
+		) {
 		return 1;
-	} else if (strcmp(value, "no") == 0 || strcmp(value, "false") == 0) {
+	} else if (strcmp(value, "no") == 0
+		|| strcmp(value, "n") == 0
+		|| strcmp(value, "false") == 0) {
 		return 0;
 	}
 

--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -185,7 +185,7 @@ void cli_getopts(int argc, char ** argv) {
 	cli_opts.bind_port = NULL;
 	cli_opts.keepalive_arg = NULL;
 #ifndef DISABLE_ZLIB
-	opts.allow_compress = 1;
+	opts.compression = DROPBEAR_CLI_COMPRESSION;
 #endif
 #if DROPBEAR_USER_ALGO_LIST
 	opts.cipher_list = NULL;
@@ -579,7 +579,7 @@ void loadidentityfile(const char* filename, int warnfail) {
 static char** multihop_args(const char* argv0, const char* prior_hops) {
 	/* null terminated array */
 	char **args = NULL;
-	size_t max_args = 14, pos = 0, len;
+	size_t max_args = 16, pos = 0, len;
 #if DROPBEAR_CLI_PUBKEY_AUTH
 	m_list_elem *iter;
 #endif
@@ -619,6 +619,15 @@ static char** multihop_args(const char* argv0, const char* prior_hops) {
 		args[pos] = m_strdup("BatchMode=yes");
 		pos++;
 	}
+
+#ifndef DISABLE_ZLIB
+	if (opts.compression) {
+		args[pos] = m_strdup("-o");
+		pos++;
+		args[pos] = m_strdup("Compression=yes");
+		pos++;
+	}
+#endif
 
 	if (cli_opts.proxycmd) {
 		args[pos] = m_strdup("-J");
@@ -725,7 +734,7 @@ static void parse_multihop_hostname(const char* orighostarg, const char* argv0) 
 
 #ifndef DISABLE_ZLIB
 		/* This outer stream will be incompressible since it's encrypted. */
-		opts.allow_compress = 0;
+		opts.compression = 0;
 #endif
 	}
 
@@ -969,6 +978,9 @@ static void add_extendedopt(const char* origstr) {
 		dropbear_log(LOG_INFO, "Available options:\n"
 			"\tBatchMode\n"
 			"\tBindAddress\n"
+#ifndef DISABLE_ZLIB
+			"\tCompression\n"
+#endif
 			"\tDisableTrivialAuth\n"
 #if DROPBEAR_CLI_ANYTCPFWD
 			"\tExitOnForwardFailure\n"
@@ -1003,6 +1015,19 @@ static void add_extendedopt(const char* origstr) {
 
 	if (match_extendedopt(&optstr, "BindAddress") == DROPBEAR_SUCCESS) {
 		cli_opts.bind_arg = optstr;
+		return;
+	}
+
+	if (match_extendedopt(&optstr, "Compression") == DROPBEAR_SUCCESS) {
+		int flag = parse_flag_value(optstr);
+#ifndef DISABLE_ZLIB
+		/* Compression compiled in */
+		opts.compression = flag;
+#else
+		if (flag) {
+			dropbear_log(LOG_WARNING, "compression is not supported");
+		}
+#endif
 		return;
 	}
 

--- a/src/common-kex.c
+++ b/src/common-kex.c
@@ -150,7 +150,6 @@ static void switch_keys() {
 		ses.keys->algo_kex = ses.newkeys->algo_kex;
 		ses.keys->algo_hostkey = ses.newkeys->algo_hostkey;
 		ses.keys->algo_signature = ses.newkeys->algo_signature;
-		ses.keys->allow_compress = 0;
 		m_free(ses.newkeys);
 		ses.newkeys = NULL;
 		kexinitialise();
@@ -208,7 +207,7 @@ static void kex_setup_compress(void) {
 	ses.compress_algos_s2c = ssh_nocompress;
 #else
 
-	if (!opts.allow_compress) {
+	if (!opts.compression) {
 		ses.compress_algos_c2s = ssh_nocompress;
 		ses.compress_algos_s2c = ssh_nocompress;
 		return;

--- a/src/default_options.h
+++ b/src/default_options.h
@@ -216,6 +216,11 @@ not as a server, due to concerns over its strength. Set to 0 to allow
 group1 in Dropbear server too */
 #define DROPBEAR_DH_GROUP1_CLIENTONLY 1
 
+/* Compression is disabled by default. Can be enabled at runtime
+ * with -o compression=yes
+ */
+#define DROPBEAR_CLI_COMPRESSION 0
+
 /* Control the memory/performance/compression tradeoff for zlib.
  * Set windowBits=8 for least memory usage, see your system's
  * zlib.h for full details.

--- a/src/runopts.h
+++ b/src/runopts.h
@@ -45,9 +45,8 @@ typedef struct runopts {
 	int usingsyslog;
 
 #ifndef DISABLE_ZLIB
-	/* Whether any compression is allowed. The specific method used
-	 * varies between client and server, it will be set up by kex_setup_compress() */
-	int allow_compress;
+	/* whether compression should be advertised */
+	int compression;
 #endif
 
 #if DROPBEAR_USER_ALGO_LIST

--- a/src/session.h
+++ b/src/session.h
@@ -106,9 +106,6 @@ struct key_context {
 	const struct dropbear_kex *algo_kex;
 	enum signkey_type algo_hostkey; /* server key type */
 	enum signature_type algo_signature; /* server signature type */
-
-	int allow_compress; /* whether compression has started (useful in 
-							zlib@openssh.com delayed compression case) */
 };
 
 struct packetlist;

--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -196,7 +196,7 @@ void svr_getopts(int argc, char ** argv) {
 	svr_opts.reexec_childpipe = -1;
 
 #ifndef DISABLE_ZLIB
-	opts.allow_compress = 1;
+	opts.compression = 1;
 #endif 
 
 	/* not yet


### PR DESCRIPTION
Compression can be enabled with -o compression=y
or with compile time DROPBEAR_CLI_COMPRESSION option.