### PR TITLE
Add -Q to query supported algorithms

### DIFF
--- a/manpages/dbclient.1
+++ b/manpages/dbclient.1
@@ -220,6 +220,11 @@ The specified command will be requested as a subsystem, used for sftp. Dropbear 
 .B \-b \fI[address][:port]
 Bind to a specific local address when connecting to the remote host. This can be used to choose from
 multiple outgoing interfaces. Either address or port (or both) can be given.
+
+.TP
+.B \-Q \fIalgo
+Query supported algorithms. Options are kex, sig, cipher, mac, compress
+
 .TP
 .B \-V
 Print the version

--- a/manpages/dropbear.8
+++ b/manpages/dropbear.8
@@ -133,6 +133,11 @@ options when using forced command.
 .B \-D \fIauthorized_keys_dir
 Specify the directory to use for authorized_keys files. The default is ~/.ssh , paths with
 a leading ~/ will be home directory expanded.
+
+.TP
+.B \-Q \fIalgo
+Query supported algorithms. Options are kex, sig, cipher, mac, compress
+
 .TP
 .B \-V
 Print the version

--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -97,6 +97,7 @@ static void printhelp() {
 					"-m <MAC list> Specify preferred MACs for packet verification (or '-m help')\n"
 #endif
 					"-b    [bind_address][:bind_port]\n"
+					"-Q    <algo>   Print supported algorithms, or -Q help\n"
 					"-V    Version\n"
 #if DEBUG_TRACE
 					"-v    verbose (repeat for more verbose)\n"
@@ -139,6 +140,7 @@ void cli_getopts(int argc, char ** argv) {
 	const char *proxycmd_arg = NULL;
 	const char *remoteport_arg = NULL;
 	const char *username_arg = NULL;
+	const char *algo_print_arg = NULL;
 	char c;
 
 	/* see printhelp() for options */
@@ -287,6 +289,9 @@ void cli_getopts(int argc, char ** argv) {
 				case 'l':
 					next = &username_arg;
 					break;
+				case 'Q':
+					next = &algo_print_arg;
+					break;
 				case 'h':
 					printhelp();
 					exit(EXIT_SUCCESS);
@@ -410,6 +415,11 @@ void cli_getopts(int argc, char ** argv) {
 	/* -c help doesn't need a hostname */
 	parse_ciphers_macs();
 #endif
+
+	if (algo_print_arg) {
+		print_algos(algo_print_arg);
+		/* No return */
+	}
 
 	if (host_arg == NULL) { /* missing hostname */
 		printhelp();
@@ -544,7 +554,6 @@ void cli_getopts(int argc, char ** argv) {
 		loadidentityfile(DROPBEAR_DEFAULT_CLI_AUTHKEY, 0);
 	}
 #endif
-
 }
 
 #if DROPBEAR_CLI_PUBKEY_AUTH

--- a/src/common-runopts.c
+++ b/src/common-runopts.c
@@ -171,3 +171,47 @@ out:
 	m_free(spec_copy);
 	return ret;
 }
+
+void print_algos(const char* algo) {
+	algo_type *list = NULL, *a = NULL;
+	int need_data = 0;
+
+	if (strcmp(algo, "kex") == 0) {
+		list = sshkex;
+		/* data = 0 kexes aren't algorithms */
+		need_data = 1;
+	} else if (strcmp(algo, "sig") == 0) {
+		list = sigalgs;
+	} else if (strcmp(algo, "cipher") == 0) {
+		list = sshciphers;
+	} else if (strcmp(algo, "mac") == 0) {
+		list = sshhashes;
+	} else if (strcmp(algo, "compress") == 0) {
+#ifndef DISABLE_ZLIB
+		if (opts.compression) {
+			list = ssh_compress;
+		} else {
+			list = ssh_nocompress;
+		}
+#else
+		list = ssh_nocompress;
+#endif
+	} else {
+		printf("kex\nsig\ncipher\nmac\ncompress\n");
+		if (strcmp(algo, "help") == 0) {
+			exit(0);
+		} else {
+			printf("Unknown -Q '%s'\n", algo);
+			exit(1);
+		}
+	}
+
+	for (a = list; a->name != NULL; a++) {
+		if (need_data && a->data == NULL) {
+			continue;
+		}
+		printf("%s\n", a->name);
+	}
+
+	exit(0);
+}

--- a/src/runopts.h
+++ b/src/runopts.h
@@ -30,6 +30,7 @@
 #include "buffer.h"
 #include "auth.h"
 #include "forward.h"
+#include "dbhelpers.h"
 
 typedef struct runopts {
 
@@ -214,6 +215,7 @@ void cli_getopts(int argc, char ** argv);
 #if DROPBEAR_USER_ALGO_LIST
 void parse_ciphers_macs(void);
 #endif
+void print_algos(const char* algo) ATTRIB_NORETURN;
 
 void print_version(void);
 void parse_recv_window(const char* recv_window_arg);
@@ -226,5 +228,6 @@ void loadidentityfile(const char* filename, int warnfail);
 #if DROPBEAR_USE_SSH_CONFIG
 void read_config_file(char* filename, FILE* config_file, cli_runopts* options);
 #endif
+
 
 #endif /* DROPBEAR_RUNOPTS_H_ */

--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -120,6 +120,7 @@ static void printhelp(const char * progname) {
                                         "-A <authplugin>[,<options>]\n"
                                         "               Enable external public key auth through <authplugin>\n"
 #endif
+					"-Q    <algo>   Print supported algorithms, or -Q help\n"
 					"-V    Version\n"
 #if DEBUG_TRACE
 					"-v    verbose (repeat for more verbose)\n"
@@ -155,6 +156,7 @@ void svr_getopts(int argc, char ** argv) {
 	char* maxauthtries_arg = NULL;
 	char* reexec_fd_arg = NULL;
 	char* keyfile = NULL;
+	char *algo_print_arg = NULL;
 	char c;
 #if DROPBEAR_PLUGIN
         char* pubkey_plugin = NULL;
@@ -350,6 +352,9 @@ void svr_getopts(int argc, char ** argv) {
 				case 'g':
 					break;
 #endif
+				case 'Q':
+					next = &algo_print_arg;
+					break;
 				case 'h':
 					printhelp(argv[0]);
 					exit(EXIT_SUCCESS);
@@ -504,6 +509,10 @@ void svr_getopts(int argc, char ** argv) {
 		svr_opts.pubkey_plugin_options = args;
 	}
 #endif
+	if (algo_print_arg) {
+		print_algos(algo_print_arg);
+		/* No return */
+	}
 }
 
 static void addportandaddress(const char* spec) {


### PR DESCRIPTION
Run by itself it will print the algorithms specified at compile time. For the client the lists will be modified by "-o Compression" or -c/-m arguments.

Closes #356