### PR TITLE
Fixes for 32-bit and old debian

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,7 @@ config.status: patch-stamp configure
 
 build: deb-checkdir build-stamp
 build-stamp: config.status
-	$(MAKE) CC='$(CC)' LD='$(CC)'
+	$(MAKE)
 	touch build-stamp
 
 clean: deb-checkdir deb-checkuid

--- a/src/sntrup761.c
+++ b/src/sntrup761.c
@@ -1640,9 +1640,9 @@ __attribute__((unused))
 static inline
 int crypto_int64_ones_num(crypto_int64 crypto_int64_x) {
   crypto_int64_unsigned crypto_int64_y = crypto_int64_x;
-  const crypto_int64 C0 = 0x5555555555555555;
-  const crypto_int64 C1 = 0x3333333333333333;
-  const crypto_int64 C2 = 0x0f0f0f0f0f0f0f0f;
+  const crypto_int64 C0 = INT64_C(0x5555555555555555);
+  const crypto_int64 C1 = INT64_C(0x3333333333333333);
+  const crypto_int64 C2 = INT64_C(0x0f0f0f0f0f0f0f0f);
   crypto_int64_y -= ((crypto_int64_y >> 1) & C0);
   crypto_int64_y = (crypto_int64_y & C1) + ((crypto_int64_y >> 2) & C1);
   crypto_int64_y = (crypto_int64_y + (crypto_int64_y >> 4)) & C2;


### PR DESCRIPTION
This should allow building mlkem and sntrup on 32 bit platforms, and using the included debian/ directory with old compilers that accept `-std=gnu99`

The whole Dropbear included debian/ directory is ancient and unmaintained, but is kept since it is still being used on old distros.