### PR TITLE
Suggest libcrypt-dev for crypt()

### DIFF
--- a/configure
+++ b/configure
@@ -10113,15 +10113,17 @@ fi
 if test "x$ac_cv_func_getpass" != xyes; then
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: " >&5
 printf "%s\n" "$as_me: " >&6;}
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: getpass() not available, dbclient will only have public-key authentication" >&5
-printf "%s\n" "$as_me: getpass() not available, dbclient will only have public-key authentication" >&6;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: getpass() not available, dbclient will only have public-key authentication" >&5
+printf "%s\n" "$as_me: WARNING: getpass() not available, dbclient will only have public-key authentication" >&2;}
 fi
 
 if test "t$found_crypt_func" != there; then
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: " >&5
 printf "%s\n" "$as_me: " >&6;}
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: crypt() not available, dropbear server will not have password authentication" >&5
-printf "%s\n" "$as_me: crypt() not available, dropbear server will not have password authentication" >&6;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: crypt() is not available, dropbear server will not have password authentication" >&5
+printf "%s\n" "$as_me: WARNING: crypt() is not available, dropbear server will not have password authentication" >&2;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Some platforms require libcrypt-dev package or similar" >&5
+printf "%s\n" "$as_me: Some platforms require libcrypt-dev package or similar" >&6;}
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: " >&5

--- a/configure.ac
+++ b/configure.ac
@@ -942,12 +942,13 @@ fi
 
 if test "x$ac_cv_func_getpass" != xyes; then
 AC_MSG_NOTICE()
-AC_MSG_NOTICE([getpass() not available, dbclient will only have public-key authentication])
+AC_MSG_WARN([getpass() not available, dbclient will only have public-key authentication])
 fi
 
 if test "t$found_crypt_func" != there; then
 AC_MSG_NOTICE()
-AC_MSG_NOTICE([crypt() not available, dropbear server will not have password authentication])
+AC_MSG_WARN([crypt() is not available, dropbear server will not have password authentication])
+AC_MSG_NOTICE([Some platforms require libcrypt-dev package or similar])
 fi
 
 AC_MSG_NOTICE()


### PR DESCRIPTION
Recent glibc doesn't include crypt(), it's now provided by libxcrypt.

Necessary for ubuntu 26.04