### PR TITLE
Fix too-low pubkey key query count

### DIFF
--- a/src/svr-authpubkey.c
+++ b/src/svr-authpubkey.c
@@ -173,9 +173,9 @@ void svr_auth_pubkey(int valid_user) {
 		 * Start counting failures (incrfail) only when it's reaching
 		 * the limit.
 		 */
-		unsigned int free_query_limit = 0;
-			MAX(0, (int)svr_opts.maxauthtries - MAX_PUBKEY_QUERIES);
-		int incrfail = ses.authstate.serv_pubkey_query_count > free_query_limit;
+		unsigned int free_query_limit =
+			MAX(0, MAX_PUBKEY_QUERIES - (int)svr_opts.maxauthtries);
+		int incrfail = ses.authstate.serv_pubkey_query_count >= free_query_limit;
 		send_msg_userauth_failure(0, incrfail);
 		ses.authstate.serv_pubkey_query_count++;
 		goto out;


### PR DESCRIPTION
Dropbear 2026.90 added a limit to the number of queries that could be made to a server when determining usable keys. This was intended to be set to 15 (MAX_PUBKEY_QUERIES) but the logic was incorrect (and also debug code was accidentally committed). This meant only 10 (default MAX_AUTH_TRIES/-T) tried keys would be allowed - not a huge difference.

Reported by Rui Salvaterra

Fixes: db0d3fd0a9e9 ("Limit server number of public key queries")

Fixes #398 