### PR TITLE
Check packet length for integer overflow

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -278,12 +278,12 @@ static int read_packet_init() {
 
 	TRACE2(("packet size is %u, block %u mac %u", len, blocksize, macsize))
 
-
-	/* check packet length */
+	/* check packet length. plen max to catch integer wraparound. */
 	if ((len > RECV_MAX_PACKET_LEN) ||
+	    (plen > RECV_MAX_PACKET_LEN) ||
 		(plen < blocksize) ||
 		(plen % blocksize != 0)) {
-		dropbear_exit("Integrity error (bad packet size %u)", len);
+		dropbear_exit("Integrity error (bad packet size %u)", plen);
 	}
 
 	if (len > ses.readbuf->size) {


### PR DESCRIPTION
The packet length provided by a peer could wrap around calculating "len", which would then pass the length check. Also check "plen" directly.

This doesn't have any functional effect, since subsequent buf_getptr() and buf_getwriteptr() would catch the incorrect length before use in decrypt_packet().

Reported by Yiyi Wang, Tsinghua University