### PR TITLE
Guard dropbearmulti entry declarations with DROPBEAR_MULTI

### DIFF
--- a/src/dbutil.h
+++ b/src/dbutil.h
@@ -106,12 +106,21 @@ int fd_read_pending(int fd);
 #define DROPBEAR_FD_ZERO(fds) FD_ZERO(fds)
 #endif
 
-/* dropbearmulti entry points */
+/* dropbearmulti entry points.
+ *
+ * These declarations are only used by the combined "dropbearmulti" binary.
+ * Guard them behind DROPBEAR_MULTI so that builds which compile the
+ * individual programs as separate objects can rename each program's main()
+ * to its own entry point (e.g. via -Dmain=<prog>_main) without clashing with
+ * the 3-argument dropbear_main() declared here.
+ */
+#if DROPBEAR_MULTI
 int dropbear_main(int argc, char ** argv, const char * multipath);
 int cli_main(int argc, char ** argv);
 int dropbearkey_main(int argc, char ** argv);
 int dropbearconvert_main(int argc, char ** argv);
 int scp_main(int argc, char ** argv);
+#endif
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 


### PR DESCRIPTION
The entry-point prototypes in dbutil.h (dropbear_main, cli_main, dropbearkey_main, dropbearconvert_main, scp_main) are only used by the combined "dropbearmulti" binary, yet they are declared unconditionally.

When dropbear is built as separate programs by an external build system that renames each program's main() to a unique symbol (for example with -Dmain=dropbear_main so the object can be registered as a named entry point), the 3-argument dropbear_main() prototype declared here conflicts with the renamed 2-argument main().

Guard the declarations with DROPBEAR_MULTI so they only appear when the multi binary is actually being built. No functional change for the default or MULTI=1 builds.