### PR TITLE
Fix typo in error message for missing hostname

### DIFF
--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -423,7 +423,7 @@ void cli_getopts(int argc, char ** argv) {
 
 	if (host_arg == NULL) { /* missing hostname */
 		printhelp();
-		dropbear_exit("Remote host needs to provided.");
+		dropbear_exit("Remote host needs to be provided.");
 	}
 	TRACE(("host is: %s", host_arg))
 


### PR DESCRIPTION
I just noticed this while trying dbclient for the first time. No problem if you don't want to change this error message in case people are relying on its current shape.