### PR TITLE
Make -t two factor and plugins deprecated

### DIFF
--- a/configure
+++ b/configure
@@ -1391,7 +1391,8 @@ Optional Features:
   --disable-openpty       Don't use openpty, use alternative method
   --disable-syslog        Don't include syslog support
   --disable-shadow        Don't use shadow passwords (if available)
-  --enable-plugin         Enable support for External Public Key
+  --enable-plugin-deprecated
+                          Enable support for External Public Key
                           Authentication plug-in
   --enable-fuzz           Build fuzzing. Not recommended for deployment.
   --enable-bundled-libtom Force using bundled libtomcrypt/libtommath even if a
@@ -5836,6 +5837,7 @@ printf "%s\n" "$as_me: Using shadow passwords if available" >&6;}
 fi
 
 
+# Plugin support will be removed soon. Open a github issue if you're using it.
 # Check whether --enable-plugin was given.
 if test ${enable_plugin+y}
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -344,8 +344,9 @@ AC_ARG_ENABLE(shadow,
 	]
 )
 
+# Plugin support will be removed soon. Open a github issue if you're using it.
 AC_ARG_ENABLE(plugin,
-	[AS_HELP_STRING([--enable-plugin], [Enable support for External Public Key Authentication plug-in])],
+	[AS_HELP_STRING([--enable-plugin-deprecated], [Enable support for External Public Key Authentication plug-in])],
 	[
 		AC_DEFINE(DROPBEAR_PLUGIN, 1, External Public Key Authentication)
 		AC_MSG_NOTICE(Enabling support for External Public Key Authentication)

--- a/src/default_options.h
+++ b/src/default_options.h
@@ -403,4 +403,13 @@ runtime with -M. 0 disables this feature. */
 #define DEFAULT_PATH "/usr/bin:/bin"
 #define DEFAULT_ROOT_PATH "/usr/sbin:/usr/bin:/sbin:/bin"
 
+/* Features pending deletion. These will be removed in a future release
+   since they don't seem to be used much. Open a github issue if you
+   want to keep them.
+ */
+/* Server "-t" two factor auth */
+#define DEPRECATED_TWO_FACTOR 0
+
+/* Plugins are set with configure --enable-plugin-deprecated */
+
 #endif /* DROPBEAR_DEFAULT_OPTIONS_H_ */

--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -85,7 +85,9 @@ static void printhelp(const char * progname) {
 					"-s		Disable password logins\n"
 					"-g		Disable password logins for root\n"
 					"-B		Allow blank password logins\n"
+#if DEPRECATED_TWO_FACTOR
 					"-t		Enable two-factor authentication (both password and public key required)\n"
+#endif
 #endif
 					"-T		Maximum authentication tries (default %d)\n"
 #if DROPBEAR_SVR_LOCALANYFWD
@@ -344,9 +346,11 @@ void svr_getopts(int argc, char ** argv) {
 				case 'B':
 					svr_opts.allowblankpass = 1;
 					break;
+#if DEPRECATED_TWO_FACTOR
 				case 't':
 					svr_opts.multiauthmethod = 1;
 					break;
+#endif
 #else
 				case 's':
 				case 'g':


### PR DESCRIPTION
These are now disabled by default, and require action to re-enable. If you are using these please open a github issue. Otherwise they will be removed in a future release.

---

Two factor auth has had a couple of security issues, and was only added in the first place to mitigate external security policy requirements. It complicates the code.

plugin support is an extra codepath to maintain, and the code style is incongruous to the rest of Dropbear, it probably shouldn't have been merged in the first place. It doesn't seem to be widely used.

If there is widespread demand and users are willing to support these they can be kept, but otherwise I'll get rid of them in a future release.