### PR TITLE
dbclient: don't treat -ogatewayports=no as yes

### DIFF
--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -1066,7 +1066,7 @@ static void add_extendedopt(const char* origstr) {
 
 #if DROPBEAR_CLI_LOCALTCPFWD
 	if (match_extendedopt(&optstr, "GatewayPorts") == DROPBEAR_SUCCESS) {
-		opts.listen_fwd_all = 1;
+		opts.listen_fwd_all = parse_flag_value(optstr);
 		return;
 	}
 #endif


### PR DESCRIPTION
Any -o gatewayports argument was treated as yes.

Fixes: 3341b6767f62 ("cli-runopts.c: support more options")
#269 