### PR TITLE
Fix crash on rejected stream forward request

### DIFF
--- a/src/svr-streamfwd.c
+++ b/src/svr-streamfwd.c
@@ -250,7 +250,9 @@ out:
         /* we only free it if a listener wasn't created, since the listener
          * has to remember it if it's to be cancelled */
         m_free(request_path);
-        m_free(tcpinfo->socket_path);
+        if (tcpinfo) {
+            m_free(tcpinfo->socket_path);
+        }
         m_free(tcpinfo);
     }
 


### PR DESCRIPTION
A NULL pointer dereference could occur when rejecting a stream forward request. This occurs post-auth and is not exploitable. Found by oss-fuzz https://issues.oss-fuzz.com/issues/525567492

Fixes: 7a8528974206 ("Support for remote forwarding with unix sockets")
#402 