### PR TITLE
Use explicit void in no-argument function definitions

### DIFF
--- a/src/common-kex.c
+++ b/src/common-kex.c
@@ -117,7 +117,7 @@ void send_msg_kexinit() {
 
 }
 
-static void switch_keys() {
+static void switch_keys(void) {
 	TRACE2(("enter switch_keys"))
 	if (!(ses.kexstate.sentkexinit && ses.kexstate.recvkexinit)) {
 		dropbear_exit("Unexpected newkeys message");

--- a/src/common-session.c
+++ b/src/common-session.c
@@ -503,7 +503,7 @@ void ignore_recv_response() {
 	TRACE(("Ignored msg_request_response"))
 }
 
-static void send_msg_keepalive() {
+static void send_msg_keepalive(void) {
 	time_t old_time_idle = ses.last_packet_time_idle;
 	struct Channel *chan = get_any_ready_channel();
 

--- a/src/dbrandom.c
+++ b/src/dbrandom.c
@@ -129,7 +129,7 @@ void addrandom(const unsigned char * buf, unsigned int len)
 	sha256_done(&hs, hashpool);
 }
 
-static void write_urandom()
+static void write_urandom(void)
 {
 #if DROPBEAR_FUZZ
 	if (fuzz.fuzzing) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -475,7 +475,7 @@ static int packet_is_okay_kex(unsigned char type) {
 	return 1;
 }
 
-static void enqueue_reply_packet() {
+static void enqueue_reply_packet(void) {
 	struct packetlist * new_item = NULL;
 	new_item = m_malloc(sizeof(struct packetlist));
 	new_item->next = NULL;

--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -38,7 +38,7 @@ static void printhelp(const char * progname);
 static void addportandaddress(const char* spec);
 static void loadhostkey(const char *keyfile, int fatal_duplicate);
 static void addhostkey(const char *keyfile);
-static void load_banner();
+static void load_banner(void);
 
 static void printhelp(const char * progname) {
 
@@ -766,7 +766,7 @@ void load_all_hostkeys() {
 	}
 }
 
-static void load_banner() {
+static void load_banner(void) {
 	struct stat buf;
 	if (stat(svr_opts.bannerfile, &buf) != 0) {
 		dropbear_log(LOG_WARNING, "Error opening banner file '%s'",


### PR DESCRIPTION
Replace empty parameter lists `()` with `(void)` in static function
definitions. In C99/C11, `func()` is an unprototyped function that
accepts any arguments, while `func(void)` explicitly declares no
parameters. This silences `-Wstrict-prototypes` warnings on pedantic
compilers.

Files changed:
- `src/common-kex.c`: `switch_keys()`
- `src/common-session.c`: `send_msg_keepalive()`
- `src/dbrandom.c`: `write_urandom()`
- `src/packet.c`: `enqueue_reply_packet()`
- `src/svr-runopts.c`: `load_banner()` (forward declaration + definition)