### PR TITLE
Allow localoptions.h to override individual ECC curves

### DIFF
--- a/src/sysoptions.h
+++ b/src/sysoptions.h
@@ -161,9 +161,15 @@
 #define LTM_DESC
 #endif
 
+#ifndef DROPBEAR_ECC_256
 #define DROPBEAR_ECC_256 (DROPBEAR_ECC)
+#endif
+#ifndef DROPBEAR_ECC_384
 #define DROPBEAR_ECC_384 (DROPBEAR_ECC)
+#endif
+#ifndef DROPBEAR_ECC_521
 #define DROPBEAR_ECC_521 (DROPBEAR_ECC)
+#endif
 
 /* Only include necessary ECC curves building libtomcrypt */
 #define LTC_NO_CURVES


### PR DESCRIPTION
`sysoptions.h` currently defines `DROPBEAR_ECC_256/384/521` unconditionally,
so any per-curve setting in `localoptions.h` is silently overwritten.

Wrapping them in `#ifndef` guards lets users enable only specific curves
(e.g. only P-256 on a constrained device) without needing to patch
`sysoptions.h` directly.