### PR TITLE
svr-kex: use explicit void in svr_ensure_hostkey definition

### DIFF
--- a/src/svr-kex.c
+++ b/src/svr-kex.c
@@ -114,7 +114,7 @@ void recv_msg_kexdh_init() {
 
 #if DROPBEAR_DELAY_HOSTKEY
 
-static void svr_ensure_hostkey() {
+static void svr_ensure_hostkey(void) {
 
 	const char* fn = NULL;
 	char *expand_fn = NULL;


### PR DESCRIPTION
Missed during #447 — svr_ensure_hostkey is guarded by #if DROPBEAR_DELAY_HOSTKEY so the warning only surfaces when that feature is enabled.