### PR TITLE
includes: guard environ declaration against macro definition

### DIFF
--- a/src/includes.h
+++ b/src/includes.h
@@ -184,7 +184,9 @@ typedef u_int32_t uint32_t;
 #include <dlfcn.h>
 #endif
 
+#ifndef environ
 extern char** environ;
+#endif
 
 #include "fake-rfc2553.h"
 


### PR DESCRIPTION
Some platforms provide environ as a macro (e.g. NuttX in stdlib.h), where the unconditional declaration fails to compile. unistd.h is already included and prototypes environ on POSIX, so guard the fallback with #ifndef environ.