### PR TITLE
Avoid following symlinks when writing files

### DIFF
--- a/src/dbutil.c
+++ b/src/dbutil.c
@@ -568,7 +568,8 @@ int buf_writefile(buffer * buf, const char * filename, int skip_exist) {
 	int ret = DROPBEAR_FAILURE;
 	int fd = -1;
 
-	fd = open(filename, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+	fd = open(filename, O_RDWR | O_CREAT | O_EXCL | O_NOFOLLOW,
+		S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		/* If generating keys on connection (skip_exist) it's OK to get EEXIST
 		- we probably just lost a race with another connection to generate the key */

--- a/src/dbutil.c
+++ b/src/dbutil.c
@@ -563,6 +563,53 @@ int buf_getline(buffer * line, FILE * authfile) {
 	return DROPBEAR_SUCCESS;
 }	
 
+/* Returns DROPBEAR_SUCCESS or DROPBEAR_FAILURE */
+int buf_writefile(buffer * buf, const char * filename, int skip_exist) {
+	int ret = DROPBEAR_FAILURE;
+	int fd = -1;
+
+	fd = open(filename, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+	if (fd < 0) {
+		/* If generating keys on connection (skip_exist) it's OK to get EEXIST
+		- we probably just lost a race with another connection to generate the key */
+		if (skip_exist && errno == EEXIST) {
+			ret = DROPBEAR_SUCCESS;
+		} else {
+			dropbear_log(LOG_ERR, "Couldn't create new file %s: %s",
+				filename, strerror(errno));
+		}
+
+		goto out;
+	}
+
+	/* write the file now */
+	while (buf->pos != buf->len) {
+		int len = write(fd, buf_getptr(buf, buf->len - buf->pos),
+				buf->len - buf->pos);
+		if (len == -1 && errno == EINTR) {
+			continue;
+		}
+		if (len <= 0) {
+			dropbear_log(LOG_ERR, "Failed writing file %s: %s",
+				filename, strerror(errno));
+			goto out;
+		}
+		buf_incrpos(buf, len);
+	}
+
+	ret = DROPBEAR_SUCCESS;
+
+out:
+	if (fd >= 0) {
+		if (fsync(fd) != 0) {
+			dropbear_log(LOG_ERR, "fsync of %s failed: %s", filename, strerror(errno));
+		}
+		m_close(fd);
+	}
+	return ret;
+}
+
+
 /* make sure that the socket closes */
 void m_close(int fd) {
 	int val;

--- a/src/dbutil.h
+++ b/src/dbutil.h
@@ -69,6 +69,7 @@ int connect_unix(const char* addr);
 #endif
 int buf_readfile(buffer* buf, const char* filename);
 int buf_getline(buffer * line, FILE * authfile);
+int buf_writefile(buffer * buf, const char * filename, int skip_exist);
 
 void m_close(int fd);
 void setnonblocking(int fd);

--- a/src/dropbearkey.c
+++ b/src/dropbearkey.c
@@ -367,7 +367,7 @@ static void printpubkey(sign_key * key, int keytype, const char * comment, int c
 
 		/* open() to use O_EXCL, then use a FILE* for fprintf().
 		 * dprintf() is only posix2008 onwards */
-		pubkey_fd = open(filename_pub, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+		pubkey_fd = open(filename_pub, O_RDWR | O_CREAT | O_NOFOLLOW | O_EXCL,S_IRUSR | S_IWUSR);
 		if (pubkey_fd >= 0) {
 			/* Convert the fd to a FILE*. The underlying FD is closed
 			 * by later fclose() */

--- a/src/gensignkey.c
+++ b/src/gensignkey.c
@@ -8,52 +8,6 @@
 #include "signkey.h"
 #include "dbrandom.h"
 
-/* Returns DROPBEAR_SUCCESS or DROPBEAR_FAILURE */
-static int buf_writefile(buffer * buf, const char * filename, int skip_exist) {
-	int ret = DROPBEAR_FAILURE;
-	int fd = -1;
-
-	fd = open(filename, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
-	if (fd < 0) {
-		/* If generating keys on connection (skip_exist) it's OK to get EEXIST
-		- we probably just lost a race with another connection to generate the key */
-		if (skip_exist && errno == EEXIST) {
-			ret = DROPBEAR_SUCCESS;
-		} else {
-			dropbear_log(LOG_ERR, "Couldn't create new file %s: %s",
-				filename, strerror(errno));
-		}
-
-		goto out;
-	}
-
-	/* write the file now */
-	while (buf->pos != buf->len) {
-		int len = write(fd, buf_getptr(buf, buf->len - buf->pos),
-				buf->len - buf->pos);
-		if (len == -1 && errno == EINTR) {
-			continue;
-		}
-		if (len <= 0) {
-			dropbear_log(LOG_ERR, "Failed writing file %s: %s",
-				filename, strerror(errno));
-			goto out;
-		}
-		buf_incrpos(buf, len);
-	}
-
-	ret = DROPBEAR_SUCCESS;
-
-out:
-	if (fd >= 0) {
-		if (fsync(fd) != 0) {
-			dropbear_log(LOG_ERR, "fsync of %s failed: %s", filename, strerror(errno));
-		}
-		m_close(fd);
-	}
-	return ret;
-}
-
 /* returns 0 on failure */
 static int get_default_bits(enum signkey_type keytype)
 {

--- a/src/keyimport.c
+++ b/src/keyimport.c
@@ -883,7 +883,7 @@ static int openssh_write(const char *filename, sign_key *key,
 	int pos = 0, len = 0, i;
 	char *header = NULL, *footer = NULL;
 	int ret = 0;
-	FILE *fp;
+	FILE *fp = NULL;
 
 #if DROPBEAR_DSS
 	if (key->type == DROPBEAR_SIGNKEY_DSS) {
@@ -1075,10 +1075,15 @@ static int openssh_write(const char *filename, sign_key *key,
 	if (strlen(filename) == 1 && filename[0] == '-') {
 		fp = stdout;
 	} else {
-		fp = fopen(filename, "wb");	  /* ensure Unix line endings */
+		fp = NULL;
+		int fd = open(filename, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW,
+			S_IRUSR | S_IWUSR);
+		if (fd >= 0) {
+			fp = fdopen(fd, "wb"); /* ensure Unix line endings */
+		}
 	}
 	if (!fp) {
-		fprintf(stderr, "Failed opening output file\n");
+		fprintf(stderr, "Failed opening output file: %s\n", strerror(errno));
 		goto error;
 	}
 	fputs(header, fp);

--- a/src/keyimport.c
+++ b/src/keyimport.c
@@ -163,36 +163,17 @@ error:
 static int dropbear_write(const char*filename, sign_key * key) {
 
 	buffer * buf;
-	FILE*fp;
-	int len;
 	int ret;
 
 	buf = buf_new(MAX_PRIVKEY_SIZE);
 	buf_put_priv_key(buf, key, key->type);
-
-	fp = fopen(filename, "w");
-	if (!fp) {
-		ret = 0;
-		goto out;
-	}
-
 	buf_setpos(buf, 0);
-	do {
-		len = fwrite(buf_getptr(buf, buf->len - buf->pos),
-				1, buf->len - buf->pos, fp);
-		buf_incrpos(buf, len);
-	} while (len > 0 && buf->len != buf->pos);
-
-	fclose(fp);
-
-	if (buf->pos != buf->len) {
-		ret = 0;
-	} else {
-		ret = 1;
-	}
-out:
+	ret = buf_writefile(buf, filename, 0);
 	buf_free(buf);
-	return ret;
+	if (ret == DROPBEAR_SUCCESS) {
+		return 1;
+	}
+	return 0;
 }
 
 

--- a/src/scp.c
+++ b/src/scp.c
@@ -1281,7 +1281,7 @@ sink(int argc, char **argv, const char *src)
 		}
 		omode = mode;
 		mode |= S_IWUSR;
-		if ((ofd = open(np, O_WRONLY|O_CREAT, mode)) < 0) {
+		if ((ofd = open(np, O_WRONLY|O_CREAT|O_NOFOLLOW, mode)) < 0) {
 bad:			run_err("%s: %s", np, strerror(errno));
 			continue;
 		}


### PR DESCRIPTION
O_NOFOLLOW is added to codepaths that write output files. This prevents problems if the destination directory/path is untrusted.

Most of these are writing private keys, so having an untrusted destination is unwise regardless.