### PR TITLE
scp: escape control characters from printed filenames

### DIFF
--- a/src/cli-auth.c
+++ b/src/cli-auth.c
@@ -94,7 +94,7 @@ void recv_msg_userauth_banner() {
 		TRACE(("recv_msg_userauth_banner: bannerlen too long: %d", bannerlen))
 		truncated = 1;
 	} else {
-		cleantext(banner);
+		cleantext(banner, 1);
 
 		/* Limit to 24 lines */
 		linecount = 1;

--- a/src/cli-authinteract.c
+++ b/src/cli-authinteract.c
@@ -102,13 +102,13 @@ void recv_msg_userauth_info_request() {
 	buf_putint(ses.writepayload, num_prompts);
 
 	if (strlen(name) > 0) {
-		cleantext(name);
+		cleantext(name, 0);
 		fprintf(stderr, "%s", name);
 	}
 	m_free(name);
 
 	if (strlen(instruction) > 0) {
-		cleantext(instruction);
+		cleantext(instruction, 0);
 		fprintf(stderr, "%s", instruction);
 	}
 	m_free(instruction);
@@ -117,7 +117,7 @@ void recv_msg_userauth_info_request() {
 		unsigned int response_len = 0;
 		cli_ses.is_trivial_auth = 0;
 		prompt = buf_getstring(ses.payload, NULL);
-		cleantext(prompt);
+		cleantext(prompt, 0);
 
 		echo = buf_getbool(ses.payload);
 

--- a/src/cli-session.c
+++ b/src/cli-session.c
@@ -394,28 +394,6 @@ static void cli_remoteclosed() {
 	dropbear_exit("Remote closed the connection");
 }
 
-/* Operates in-place turning dirty (untrusted potentially containing control
- * characters) text into clean text. 
- * Note: this is safe only with ascii - other charsets could have problems. */
-void cleantext(char* dirtytext) {
-
-	unsigned int i, j;
-	char c;
-
-	j = 0;
-	for (i = 0; dirtytext[i] != '\0'; i++) {
-
-		c = dirtytext[i];
-		/* We can ignore '\r's */
-		if ( (c >= ' ' && c <= '~') || c == '\n' || c == '\t') {
-			dirtytext[j] = c;
-			j++;
-		}
-	}
-	/* Null terminate */
-	dirtytext[j] = '\0';
-}
-
 static void recv_msg_global_request_cli(void) {
 	unsigned int wantreply = 0;
 

--- a/src/cli-tcpfwd.c
+++ b/src/cli-tcpfwd.c
@@ -266,7 +266,7 @@ static int newtcpforwarded(struct Channel * channel) {
 
 	if (iter == NULL || fwd == NULL) {
 		/* We didn't request forwarding on that port */
-		cleantext(origaddr);
+		cleantext(origaddr, 0);
 		dropbear_log(LOG_INFO, "Server sent unrequested forward from \"%s:%d\"", 
                 origaddr, origport);
 		goto out;

--- a/src/dbutil.c
+++ b/src/dbutil.c
@@ -856,3 +856,26 @@ int m_snprintf(char *str, size_t size, const char *format, ...) {
 	}
 	return ret;
 }
+
+/* Operates in-place turning dirty text (untrusted potentially containing control
+ * characters) into clean text.
+ * Only ascii (7 bit) characters are allowed.
+ * Set allow_whitespace to allow \n and \t. */
+void cleantext(char* dirtytext, int allow_whitespace) {
+
+	unsigned int i, j;
+	unsigned char c;
+
+	j = 0;
+	for (i = 0; dirtytext[i] != '\0'; i++) {
+
+		c = (unsigned char)dirtytext[i];
+		/* We can ignore '\r's */
+		if (c >= ' ' || c <= '~' || (allow_whitespace && (c == '\n' || c == '\t'))) {
+			dirtytext[j] = c;
+			j++;
+		}
+	}
+	/* Null terminate */
+	dirtytext[j] = '\0';
+}

--- a/src/dbutil.h
+++ b/src/dbutil.h
@@ -77,6 +77,7 @@ void disallow_core(void);
 int m_str_to_uint(const char* str, unsigned int *val);
 /* The same as snprintf() but exits rather than returning negative */
 int m_snprintf(char *str, size_t size, const char *format, ...);
+void cleantext(char* dirtytext, int allow_whitespace);
 
 /* Used to force mp_ints to be initialised */
 #define DEF_MP_INT(X) mp_int X = {0, 0, 0, NULL}

--- a/src/progressmeter.c
+++ b/src/progressmeter.c
@@ -55,7 +55,7 @@ static void update_progress_meter(int);
 
 static time_t start;		/* start progress */
 static time_t last_update;	/* last progress update */
-static char *file;		/* name of the file being transferred */
+static char *file;		/* name of the file being transferred, malloced */
 static off_t end_pos;		/* ending position of transfer */
 static off_t cur_pos;		/* transfer position as of last refresh */
 static volatile off_t *counter;	/* progress counter */
@@ -236,11 +236,39 @@ update_progress_meter(int ignore)
 	errno = save_errno;
 }
 
+/* Operates in-place turning dirty text (untrusted potentially containing control
+ * characters) into clean text.
+ * Only ascii (7 bit) characters are allowed.
+ * Set allow_whitespace to allow \n and \t. */
+static void cleantext(char* dirtytext, int allow_whitespace) {
+
+	unsigned int i, j;
+	unsigned char c;
+
+	j = 0;
+	for (i = 0; dirtytext[i] != '\0'; i++) {
+
+		c = (unsigned char)dirtytext[i];
+		/* We can ignore '\r's */
+		if (c >= ' ' || c <= '~' || (allow_whitespace && (c == '\n' || c == '\t'))) {
+			dirtytext[j] = c;
+			j++;
+		}
+	}
+	/* Null terminate */
+	dirtytext[j] = '\0';
+}
+
 void
 start_progress_meter(char *f, off_t filesize, off_t *ctr)
 {
 	start = last_update = time(NULL);
-	file = f;
+	if (file) {
+		xfree(file);
+		file = NULL;
+	}
+	file = xstrdup(f);
+	cleantext(file, 0);
 	end_pos = filesize;
 	cur_pos = 0;
 	counter = ctr;

--- a/src/session.h
+++ b/src/session.h
@@ -66,7 +66,6 @@ void cli_session(int sock_in, int sock_out, struct dropbear_progress_connection 
 void cli_connected(int result, int sock, void* userdata, const char *errstring);
 void cli_dropbear_exit(int exitcode, const char* format, va_list param) ATTRIB_NORETURN;
 void cli_dropbear_log(int priority, const char* format, va_list param);
-void cleantext(char* dirtytext);
 void kill_proxy_command(void);
 
 /* crypto parameters that are stored individually for transmit and receive */


### PR DESCRIPTION
When scp is built with SCPPROGRESS=1 (not default) the filenames didn't
have control characters escaped. A side-effect is that non-ascii
characters now will no longer be printed, such as utf-8 filenames. This
is only visual, the real path used for the copy is unchanged.

This uses a copy of cleantext() rather than figuring out linking to
dbutil.o.