### PR TITLE
Fix cleantext() to strip control characters

### DIFF
--- a/src/dbutil.c
+++ b/src/dbutil.c
@@ -871,7 +871,7 @@ void cleantext(char* dirtytext, int allow_whitespace) {
 
 		c = (unsigned char)dirtytext[i];
 		/* We can ignore '\r's */
-		if (c >= ' ' || c <= '~' || (allow_whitespace && (c == '\n' || c == '\t'))) {
+		if ((c >= ' ' && c <= '~') || (allow_whitespace && (c == '\n' || c == '\t'))) {
 			dirtytext[j] = c;
 			j++;
 		}

--- a/src/progressmeter.c
+++ b/src/progressmeter.c
@@ -250,7 +250,7 @@ static void cleantext(char* dirtytext, int allow_whitespace) {
 
 		c = (unsigned char)dirtytext[i];
 		/* We can ignore '\r's */
-		if (c >= ' ' || c <= '~' || (allow_whitespace && (c == '\n' || c == '\t'))) {
+		if ((c >= ' ' && c <= '~') || (allow_whitespace && (c == '\n' || c == '\t'))) {
 			dirtytext[j] = c;
 			j++;
 		}


### PR DESCRIPTION
cleantext() exists to strip non-printable bytes out of untrusted strings before
they reach the user's terminal, things like the authentication banner, the
keyboard-interactive name/instruction/prompt fields, and the origin address a
remote server supplies when opening a forwarded connection. When the function was
moved into dbutil a couple of commits back, the printable-range test was written
as `c >= ' ' || c <= '~'`, which is true for every possible byte value, so the
loop keeps everything and no longer filters anything at all. A malicious or
compromised server can then embed terminal escape sequences in a banner or a
prompt and have dbclient print them verbatim, which is exactly the injection the
function was added to prevent. The original code in cli-session.c used `&&` and
only kept the whitespace it was explicitly allowed; the copy that just landed in
progressmeter.c for the scp progress display picked up the same slip. Clang's
-Wtautological-overlap-compare points right at it, and a small harness confirms
that ESC and BEL survive the old test but are dropped once the comparisons are
joined with `&&`. This restores the printable-only behavior in both places.