### PR TITLE
avoid out-of-bounds read matching ecdsa curve identifier

### DIFF
--- a/src/ecdsa.c
+++ b/src/ecdsa.c
@@ -103,7 +103,7 @@ ecc_key *buf_get_ecdsa_pub_key(buffer* buf) {
 	}
 
 	for (curve = dropbear_ecc_curves; *curve; curve++) {
-		if (memcmp(identifier, (char*)(*curve)->name, strlen((char*)(*curve)->name)) == 0) {
+		if (strcmp((char*)identifier, (*curve)->name) == 0) {
 			break;
 		}
 	}


### PR DESCRIPTION
When a peer sends an ECDSA public key, buf_get_ecdsa_pub_key pulls the curve identifier out of the blob with buf_getstring and then walks the curve table comparing it with memcmp(identifier, name, strlen(name)). The identifier length is attacker-controlled: in the non-sk branch the only checks are that key_ident equals identifier plus the "ecdsa-sha2-" prefix and that the suffix matches, so an identifier of one byte (or even zero) gets through. Since strlen("nistp256") is 8, the memcmp then reads up to eight bytes out of an allocation that can be as small as one, running past the end of the heap buffer. It is reachable before authentication from an ordinary publickey auth request, so a remote peer controls both the trigger and the short identifier. I hit it building an ecdsa key blob with a one-character identifier under ASAN, which flags a heap-buffer-overflow read right at the memcmp. buf_getstring always NUL-terminates its result, so switching the comparison to strcmp keeps the match exact and stops as soon as either string ends, and it also drops the accidental prefix match the old memcmp allowed.