### PR TITLE
Require valid port for authorized_keys permitlisten

### DIFF
--- a/src/svr-authpubkeyoptions.c
+++ b/src/svr-authpubkeyoptions.c
@@ -359,7 +359,8 @@ svr_parse_pubkey_options(buffer *options_buf, int line_num, const char* filename
 					 * port="*" isn't supported either, since it only is useful
 					 * with a host: part. */
 
-					if (m_str_to_uint(spec, &entry->port) == DROPBEAR_SUCCESS) {
+					if (m_str_to_uint(spec, &entry->port) == DROPBEAR_SUCCESS
+						&& entry->port <= 65535) {
 						valid_option = 1;
 						TRACE(("remote forwarding allows listening on port %u",
 								entry->port));


### PR DESCRIPTION
The permitlisten authorized_keys option parses its port with m_str_to_uint but never checks the result is a real TCP port, so a value like 65536 or 4294967295 is stored into entry->port and the option is accepted as valid. permitopen had the same gap until 10d1b72 added the port <= 65535 check, but permitlisten was left as it was. The value 4294967295 is worth calling out because it happens to equal PUBKEY_OPTIONS_ANY_PORT, and although the remote-forward match doesn't treat that as a wildcard the way the local-forward match does, an out-of-range entry can never match a request anyway since bind ports are already validated to 65535 in svr-tcpfwd.c, so the restriction quietly turns into one that permits nothing rather than what was written. I noticed it while reading the two options next to each other after the permitopen change. This applies the same range check so an invalid port is rejected with the existing Badly formatted permitlisten warning instead of being accepted.