### PR TITLE
manpages: re-typeset in mdoc(7)

### DIFF
--- a/manpages/dbclient.1
+++ b/manpages/dbclient.1
@@ -1,335 +1,399 @@
-.TH dbclient 1 2023-02-01
-.SH NAME
-dbclient \- lightweight SSH client
-.SH SYNOPSIS
-.B dbclient
-[\fIflag arguments\fR] [\-p
-.I port\fR] [\-i
-.I id\fR] [\-L
-.I l\fR:\fIh\fR:\fIp\fR] [\-R
-.I l\fR:\fIh\fR:\fIp\fR] [\-l
-.IR user ]
-.I host
-.RI [ \fImore\ flags\fR ]
-.RI [ command ]
-
-.B dbclient
-[\fIargs\fR]
-[\fIuser1\fR]@\fIhost1\fR[^\fIport1\fR],[\fIuser2\fR]@\fIhost2\fR[^\fIport2\fR],...
-
-.SH DESCRIPTION
-.B dbclient
+.Dd February 1, 2023
+.Dt DBCLIENT 1
+.Os
+.Sh NAME
+.Nm dbclient
+.Nd lightweight SSH client
+.Sh SYNOPSIS
+.Nm
+.Op Ar flag arguments
+.Op Fl p Ar port
+.Op Fl i Ar id
+.Op Fl L Ar l:h:p
+.Op Fl R Ar l:h:p
+.Op Fl l Ar user
+.Ar host
+.Op Ar more flags
+.Op Ar command
+.Pp
+.Nm
+.Op Ar args
+.Ar "[user1]@host1[^port1],[user2]@host2[^port2],..."
+.Sh DESCRIPTION
+.Nm dbclient
 is the client part of Dropbear SSH
-.SH OPTIONS
-.TP
-.B command
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Ar command
 A command to run on the remote host. This will normally be run by the remote host
-using the user's shell. The command begins at the first hyphen argument after the 
+using the user's shell. The command begins at the first hyphen argument after the
 host argument. If no command is specified an interactive terminal will be opened
-(see -t and -T).
-.TP
-.B \-p \fIport
-Connect to 
-.I port
-on the remote host. Alternatively a port can be specified as hostname^port.
+(see
+.Fl t
+and
+.Fl T ) .
+.It Fl p Ar port
+Connect to
+.Ar port
+on the remote host. Alternatively a port can be specified as
+.Ar hostname Ns ^ Ns Ar port .
 Default is 22.
-.TP
-.B \-i \fIidfile
+.It Fl i Ar idfile
 Identity file.
 Read the identity key from file
-.I idfile
-(multiple allowed). This file is created with dropbearkey(1) or converted
-from OpenSSH with dropbearconvert(1). The default path ~/.ssh/id_dropbear is used
-.TP
-.B \-L\fR [\fIlistenaddress\fR]:\fIlistenport\fR:\fIhost\fR:\fIport\fR
+.Ar idfile
+(multiple allowed). This file is created with
+.Xr dropbearkey 1
+or converted
+from OpenSSH with
+.Xr dropbearconvert 1 .
+The default path
+.Pa ~/.ssh/id_dropbear
+is used.
+.It Fl L Ar [listenaddress]:listenport:host:port
 Local port forwarding.
-Forward 
-.I listenport
-on the local host through the SSH connection to 
-.I port
-on 
-.IR host .
-.TP
-.B \-R\fR [\fIlistenaddress\fR]:\fIlistenport\fR:\fIhost\fR:\fIport\fR
+Forward
+.Ar listenport
+on the local host through the SSH connection to
+.Ar port
+on
+.Ar host .
+.It Fl R Ar [listenaddress]:listenport:host:port
 Remote port forwarding.
-Forward 
-.I listenport
-on the remote host through the SSH connection to 
-.I port
-on 
-.IR host .
-.TP
-.B \-l \fIuser
+Forward
+.Ar listenport
+on the remote host through the SSH connection to
+.Ar port
+on
+.Ar host .
+.It Fl l Ar user
 Username.
 Login as
-.I user
-on the remote host. An alternative is to specify user@host.
-.TP
-.B \-t
+.Ar user
+on the remote host. An alternative is to specify
+.Ar user Ns @ Ns Ar host .
+.It Fl t
 Allocate a PTY. This is the default when no command is given, it gives a full
-interactive remote session. The main effect is that keystrokes are sent remotely 
+interactive remote session. The main effect is that keystrokes are sent remotely
 immediately as opposed to local line-based editing.
-.TP
-.B \-T
-Don't allocate a PTY. This is the default when a command is given. See -t.
-.TP
-.B \-N
+.It Fl T
+Don't allocate a PTY. This is the default when a command is given. See
+.Fl t .
+.It Fl N
 Don't request a remote shell or run any commands. Any command arguments are ignored.
-.TP
-.B \-f
-Fork into the background after authentication. A command argument (or -N) is required.
+.It Fl f
+Fork into the background after authentication. A command argument (or
+.Fl N )
+is required.
 This is useful when using password authentication.
-.TP
-.B \-g
-Allow non-local hosts to connect to forwarded ports. Applies to -L and -R
-forwarded ports, though remote connections to -R forwarded ports may be limited
+.It Fl g
+Allow non-local hosts to connect to forwarded ports. Applies to
+.Fl L
+and
+.Fl R
+forwarded ports, though remote connections to
+.Fl R
+forwarded ports may be limited
 by the ssh server.
-.TP
-.B \-y
+.It Fl y
 Always accept hostkeys if they are unknown. If a hostkey mismatch occurs the
 connection will abort as normal. If specified a second time no host key checking
 is performed at all, this is usually undesirable.
-.TP
-.B \-A
+.It Fl A
 Forward agent connections to the remote host. dbclient will use any
-OpenSSH-style agent program if available ($SSH_AUTH_SOCK will be set) for
-public key authentication.  Forwarding is only enabled if \fI-A\fR is specified.
-
+OpenSSH-style agent program if available
+.Po
+.Ev SSH_AUTH_SOCK
+will be set
+.Pc
+for
+public key authentication.  Forwarding is only enabled if
+.Fl A
+is specified.
+.Pp
 Beware that a forwarded agent connection will allow the remote server to have
 the same authentication credentials as you have used locally. A compromised
-remote server could use that to log in to other servers. 
-
+remote server could use that to log in to other servers.
+.Pp
 In many situations Dropbear's multi-hop mode is a better and more secure alternative
 to agent forwarding, avoiding having to trust the intermediate server.
-
-If the SSH agent program is set to prompt when a key is used, the 
-\fI-o DisableTrivialAuth\fR option can prevent UI confusion.
-
-.TP
-.B \-W \fIwindowsize
-Specify the per-channel receive window buffer size. Increasing this 
+.Pp
+If the SSH agent program is set to prompt when a key is used, the
+.Fl o Ar DisableTrivialAuth
+option can prevent UI confusion.
+.It Fl W Ar windowsize
+Specify the per-channel receive window buffer size. Increasing this
 may improve network performance at the expense of memory use. Use -h to see the
 default buffer size.
-.TP
-.B \-K \fItimeout_seconds
+.It Fl K Ar timeout_seconds
 Ensure that traffic is transmitted at a certain interval in seconds. This is
 useful for working around firewalls or routers that drop connections after
 a certain period of inactivity. The trade-off is that a session may be
 closed if there is a temporary lapse of network connectivity. A setting
 if 0 disables keepalives. If no response is received for 3 consecutive keepalives the connection will be closed.
-.TP
-.B \-I \fIidle_timeout
-Disconnect the session if no traffic is transmitted or received for \fIidle_timeout\fR seconds.
-.TP
-.B \-z
-By default Dropbear will send network traffic with the \fBAF21\fR setting for QoS, letting network devices give it higher priority. Some devices may have problems with that, \fI-z\fR can be used to disable it.
-.TP
-
-.\" TODO: how to avoid a line break between these two -J arguments?
-.B \-J \fIproxy_command
-.TP
-.B \-J \fI&fd
-.br
-Use the standard input/output of the program \fIproxy_command\fR rather than using
+.It Fl I Ar idle_timeout
+Disconnect the session if no traffic is transmitted or received for
+.Ar idle_timeout
+seconds.
+.It Fl z
+By default Dropbear will send network traffic with the
+.Dv AF21
+setting for QoS, letting network devices give it higher priority. Some devices may have problems with that,
+.Fl z
+can be used to disable it.
+.It Xo
+.Fl J Ar proxy_command |
+.Fl J Cm & Ns Ar fd
+.Xc
+Use the standard input/output of the program
+.Ar proxy_command
+rather than using
 a normal TCP connection. A hostname should be still be provided, as this is used for
-comparing saved hostkeys. This command will be executed as "exec proxy_command ..." with the
+comparing saved hostkeys. This command will be executed as
+.Ql exec proxy_command ...
+with the
 default shell.
-
-The second form &fd will make dbclient use the numeric file descriptor as a socket. This
+.Pp
+The second form
+.Cm & Ns Ar fd
+will make dbclient use the numeric file descriptor as a socket. This
 can be used for more complex tunnelling scenarios. Example usage with socat is
-
+.Bd -literal -offset indent
 socat EXEC:'dbclient -J &38 ev',fdin=38,fdout=38 TCP4:host.example.com:22
-
-.TP
-.B \-B \fIendhost:endport
-"Netcat-alike" mode, where Dropbear will connect to the given host, then create a
-forwarded connection to \fIendhost\fR. This will then be presented as dbclient's
+.Ed
+.It Fl B Ar endhost:endport
+.Dq Netcat-alike
+mode, where Dropbear will connect to the given host, then create a
+forwarded connection to
+.Ar endhost .
+This will then be presented as dbclient's
 standard input/output.
-.TP
-.B \-c \fIcipherlist
-Specify a comma separated list of ciphers to enable. Use \fI-c help\fR to list possibilities.
-.TP
-.B \-m \fIMAClist
-Specify a comma separated list of authentication MACs to enable. Use \fI-m help\fR to list possibilities.
-.TP
-.B \-o \fIoption
+.It Fl c Ar cipherlist
+Specify a comma separated list of ciphers to enable. Use
+.Fl c Cm help
+to list possibilities.
+.It Fl m Ar MAClist
+Specify a comma separated list of authentication MACs to enable. Use
+.Fl m Cm help
+to list possibilities.
+.It Fl o Ar option
 Can be used to give options in the format used by OpenSSH config file. This is
 useful for specifying options for which there is no separate command-line flag.
 For full details of the options listed below, and their possible values, see
-ssh_config(5). "yes"/"no" arguments also accept y/n.
-
+.Xr ssh_config 5 .
+.Cm yes Ns / Ns Cm no
+arguments also accept
+.Cm y Ns / Ns Cm n .
+.Pp
 The following options have currently been implemented:
-
-.RS
-.TP
-.B BatchMode
-Disable interactive prompts e.g. password prompts and host key confirmation. The argument must be "yes" or "no" (the default).
-.TP
-.B BindAddress
+.Bl -tag -width Ds
+.It Cm BatchMode
+Disable interactive prompts e.g. password prompts and host key confirmation. The argument must be
+.Cm yes
+or
+.Cm no
+(the default).
+.It Cm BindAddress
 Specify address and port on the local machine as the source address of the connection.
-.TP
-.B Compression
-Can be set to "yes" or "no". Default is no compression (with default
+.It Cm Compression
+Can be set to
+.Cm yes
+or
+.Cm no .
+Default is no compression (with default
 build options). Enabling compression can be a security weakness in some
 circumstances, as the size of network traffic may leak information
 about the encrypted data.
-
+.Pp
 Compression will only be used when the server also supports it.
-.TP
-.B DisableTrivialAuth
+.It Cm DisableTrivialAuth
 Disallow a server immediately
 giving successful authentication (without presenting any password/pubkey prompt).
 This avoids a UI confusion issue where it may appear that the user is accepting
 a SSH agent prompt from their local machine, but are actually accepting a prompt
 sent immediately by the remote server.
-.TP
-.B ExitOnForwardFailure
-Specifies whether dbclient should terminate the connection if it cannot set up all requested local and remote port forwardings. The argument must be "yes" or "no" (the default).
-.TP
-.B ForwardAgent
-Forward the authentication agent to the remote machine. The argument must be "yes" or "no" (the default).
-.TP
-.B GatewayPorts
-Allow to remote host to connect to local forwarded ports. The argument must be "yes" or "no" (the default).
-.TP
-.B IdentityFile
+.It Cm ExitOnForwardFailure
+Specifies whether dbclient should terminate the connection if it cannot set up all requested local and remote port forwardings. The argument must be
+.Cm yes
+or
+.Cm no
+(the default).
+.It Cm ForwardAgent
+Forward the authentication agent to the remote machine. The argument must be
+.Cm yes
+or
+.Cm no
+(the default).
+.It Cm GatewayPorts
+Allow to remote host to connect to local forwarded ports. The argument must be
+.Cm yes
+or
+.Cm no
+(the default).
+.It Cm IdentityFile
 Specify an authentication identity file path.
-.TP
-.B PasswordAuthentication
-Allow to prompt a user for a password. If the DROPBEAR_PASSWORD env is specified then it still will be used. The argument must be "yes" (the default) or "no".
-.TP
-.B Port
-Specify a listening port, like the \fI-p\fR argument.
-.TP
-.B ProxyCommand
+.It Cm PasswordAuthentication
+Allow to prompt a user for a password. If the
+.Ev DROPBEAR_PASSWORD
+env is specified then it still will be used. The argument must be
+.Cm yes
+(the default) or
+.Cm no .
+.It Cm Port
+Specify a listening port, like the
+.Fl p
+argument.
+.It Cm ProxyCommand
 Specify the proxy command to use to connect to the server.
-.TP
-.B ServerAliveInterval
+.It Cm ServerAliveInterval
 Sets a timeout interval in seconds between keep-alive messages through the encrypted channel. The default is 0 e.g. disabled.
-.TP
-.B StrictHostKeyChecking
-Use "yes" to refuse connection to hosts where the host key is not already
-correct in known_hosts. Entries must be added to known_hosts manually.
-
-Use "no" to skip the known_hosts key checking.
-
-Use "accept-new" to add new host keys to the known_hosts and
+.It Cm StrictHostKeyChecking
+Use
+.Cm yes
+to refuse connection to hosts where the host key is not already
+correct in
+.Pa known_hosts .
+Entries must be added to
+.Pa known_hosts
+manually.
+.Pp
+Use
+.Cm no
+to skip the
+.Pa known_hosts
+key checking.
+.Pp
+Use
+.Cm accept-new
+to add new host keys to the
+.Pa known_hosts
+and
 refuse to connect if the host key has changed.
-
-"ask" is the default.
-
-.TP
-.B UseSyslog
+.Pp
+.Cm ask
+is the default.
+.It Cm UseSyslog
 Send dbclient log messages to syslog in addition to stderr.
-.RE
-.TP
-.B \-s 
-The specified command will be requested as a subsystem, used for sftp. Dropbear doesn't implement sftp itself but the OpenSSH sftp client can be used eg \fIsftp -S dbclient user@host\fR
-.TP
-.B \-b \fI[address][:port]
+.El
+.It Fl s
+The specified command will be requested as a subsystem, used for sftp. Dropbear doesn't implement sftp itself but the OpenSSH sftp client can be used eg
+.Dl sftp -S dbclient user@host
+.It Fl b Ar [address][:port]
 Bind to a specific local address when connecting to the remote host. This can be used to choose from
 multiple outgoing interfaces. Either address or port (or both) can be given.
-
-.TP
-.B \-Q \fIalgo
-Query supported algorithms. Options are kex, sig, cipher, mac, compress
-
-.TP
-.B \-V
+.It Fl Q Ar algo
+Query supported algorithms. Options are kex, sig, cipher, mac, compress.
+.It Fl V
 Print the version
-
-.SH MULTI-HOP
+.El
+.Sh MULTI-HOP
 Dropbear will also allow multiple "hops" to be specified, separated by commas. In
-this case a connection will be made to the first host, then a TCP forwarded 
+this case a connection will be made to the first host, then a TCP forwarded
 connection will be made through that to the second host, and so on. Hosts other than
-the final destination will not see anything other than the encrypted SSH stream. 
-A port for a host can be specified with a caret (eg matt@martello^44 ).
-This syntax can also be used with scp or rsync (specifying dbclient as the 
+the final destination will not see anything other than the encrypted SSH stream.
+A port for a host can be specified with a caret (eg
+.Ar matt Ns @ Ns Ar martello Ns ^ Ns Ar 44 ) .
+This syntax can also be used with scp or rsync (specifying dbclient as the
 ssh/rsh command). A file can be "bounced" through multiple SSH hops, eg
-
+.Bd -literal -offset indent
 scp -S dbclient matt@martello,root@wrt,canyons:/tmp/dump .
-
+.Ed
+.Pp
 Note that hostnames are resolved by the prior hop (so "canyons" would be resolved by the host "wrt")
-in the example above, the same way as other -L TCP forwarded hosts are. Host keys are 
+in the example above, the same way as other -L TCP forwarded hosts are. Host keys are
 checked locally based on the given hostname.
-
-.SH ESCAPE CHARACTERS
-Typing a newline followed by the  key sequence \fI~.\fR (tilde, dot) will terminate a connection.
-The sequence \fI~^Z\fR (tilde, ctrl-z) will background the connection. This behaviour only
+.Sh ESCAPE CHARACTERS
+Typing a newline followed by the key sequence
+.Ql ~.
+(tilde, dot) will terminate a connection.
+The sequence
+.Ql ~^Z
+(tilde, ctrl-z) will background the connection. This behaviour only
 applies when a PTY is used.
-
-\fI~R\fR will perform a key re-exchange of ephemeral session keys.
-
-.SH ENVIRONMENT
-.TP
-.B DROPBEAR_PASSWORD
+.Pp
+.Ql ~R
+will perform a key re-exchange of ephemeral session keys.
+.Sh ENVIRONMENT
+.Bl -tag -width Ds
+.It Ev DROPBEAR_PASSWORD
 A password to use for remote authentication can be specified in the environment
-variable DROPBEAR_PASSWORD. Care should be taken that the password is not
+variable
+.Ev DROPBEAR_PASSWORD .
+Care should be taken that the password is not
 exposed to other users on a multi-user system, or stored in accessible files.
-.TP
-.B SSH_ASKPASS
+.It Ev SSH_ASKPASS
 dbclient can use an external program to request a password from a user.
-SSH_ASKPASS should be set to the path of a program that will return a password
-on standard output. This program will only be used if either DISPLAY is set and
-standard input is not a TTY, or the environment variable SSH_ASKPASS_ALWAYS is
+.Ev SSH_ASKPASS
+should be set to the path of a program that will return a password
+on standard output. This program will only be used if either
+.Ev DISPLAY
+is set and
+standard input is not a TTY, or the environment variable
+.Ev SSH_ASKPASS_ALWAYS
+is
 set.
-
-.SH FILES
-.B ~/.ssh/dropbear_config
-
+.El
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa ~/.ssh/dropbear_config
 This is the per user configuration file. A very limited subset of the keywords for
-ssh_config(5) is supported, and none of the advanced features. The file contains
-key value pairs on a single line separated with space or '='. Empty lines are ignored.
-Text starting with '#' is a comment, and also ignored.
-
+.Xr ssh_config 5
+is supported, and none of the advanced features. The file contains
+key value pairs on a single line separated with space or
+.Ql = .
+Empty lines are ignored.
+Text starting with
+.Ql #
+is a comment, and also ignored.
+.Pp
 The file is not considered if multi-hop connection is used. Values on the command line
 override the respective values in the file.
-
+.Pp
 The recognized keywords are as follows. Keywords are case insensitive and values are
 case insensitive.
-
-.TP
-.B Host
+.Bl -tag -width Ds
+.It Cm Host
 Defines the options that would be applied if this value matches the host specified
-on the command line. The next Host entry or EOF determine the list of applicable
+on the command line. The next
+.Cm Host
+entry or
+.Dv EOF
+determine the list of applicable
 options.
-
-.TP
-.B HostName
+.It Cm HostName
 Specifies the actual host name to connect to. Can be DNS name or IP address.
-
-.TP
-.B Port
+.It Cm Port
 Specifies the port number to use to connect to the remote host.
-
-.TP
-.B 
-User
+.It Cm User
 Specifies the user name to login in as.
-
-.TP
-.B
-IdentityFile
+.It Cm IdentityFile
 Specifies the file with the private key used for public key authentication with the remote
-host. The file must be in the Dropbear format. See dropbearkey(1) to generate one. A '~/' at
+host. The file must be in the Dropbear format. See
+.Xr dropbearkey 1
+to generate one.
+.Pa ~/
+at
 the start of the path will expanded to the executing user's home directory. A path that
-does not start with '/' will be treated relative to this configuration file's directory. Otherwise
+does not start with
+.Pa /
+will be treated relative to this configuration file's directory. Otherwise
 the path will be used as is.
-
+.El
+.Pp
 Because this file contains a secret it must have strict permissions to prevent abuse
 attempts - read/write for the executing user, and no access to anyone else.
-
-.SH NOTES
+.El
+.Sh NOTES
 If compiled with zlib support and if the server supports it, dbclient will
 always use compression.
-
-.SH AUTHOR
-Matt Johnston (matt@ucc.asn.au).
-.br
-Mihnea Stoenescu wrote initial Dropbear client support
-.br
-Gerrit Pape (pape@smarden.org) wrote this manual page.
-.SH SEE ALSO
-dropbear(8), dropbearkey(1)
-.P
-https://matt.ucc.asn.au/dropbear/dropbear.html
+.Sh SEE ALSO
+.Xr dropbearkey 1 ,
+.Xr dropbear 8
+.Pp
+.Lk https://matt.ucc.asn.au/dropbear/dropbear.html
+.Sh AUTHORS
+.An Matt Johnston Aq Mt matt@ucc.asn.au .
+.An Mihnea Stoenescu
+wrote initial Dropbear client support.
+.An Gerrit Pape Aq Mt pape@smarden.org
+wrote this manual page.

--- a/manpages/dropbear.8
+++ b/manpages/dropbear.8
@@ -1,277 +1,296 @@
-.TH dropbear 8
-.SH NAME
-dropbear \- lightweight SSH server
-.SH SYNOPSIS
-.B dropbear
-[\fIflag arguments\fR] [\-b
-.I banner\fR] 
-[\-r
-.I hostkeyfile\fR] [\-p [\fIaddress\fR:]\fIport\fR]
-.SH DESCRIPTION
-.B dropbear
-is a small SSH server 
-.SH OPTIONS
-.TP
-.B \-b \fIbanner
+.Dd February 1, 2023
+.Dt DROPBEAR 8
+.Os
+.Sh NAME
+.Nm dropbear
+.Nd lightweight SSH server
+.Sh SYNOPSIS
+.Nm
+.Op Ar flag arguments
+.Op Fl b Ar banner
+.Op Fl r Ar hostkeyfile
+.Op Fl p Ar [address:]port
+.Sh DESCRIPTION
+.Nm dropbear
+is a small SSH server
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl b Ar banner
 bannerfile.
 Display the contents of the file
-.I banner
+.Ar banner
 before user login (default: none).
-.TP
-.B \-r \fIhostkey
+.It Fl r Ar hostkey
 Use the contents of the file
-.I hostkey
+.Ar hostkey
 for the SSH hostkey.
 This file is generated with
-.BR dropbearkey (1) 
-or automatically with the '-R' option. See "Host Key Files" below.
-.TP
-.B \-R
-Generate hostkeys automatically. See "Host Key Files" below.
-.TP
-.B \-F
+.Xr dropbearkey 1
+or automatically with the
+.Fl R
+option. See
+.Dq Host Key Files
+below.
+.It Fl R
+Generate hostkeys automatically. See
+.Dq Host Key Files
+below.
+.It Fl F
 Don't fork into background.
-.TP
-.B \-E
+.It Fl E
 Log to standard error rather than syslog.
-.TP
-.B \-e
+.It Fl e
 Pass on the server environment to all child processes. This is required, for example,
 if Dropbear is launched on the fly from a SLURM workload manager. The environment is not
-passed by default. Note that this could expose secrets in environment variables from 
+passed by default. Note that this could expose secrets in environment variables from
 the calling process - use with caution.
-.TP
-.B \-m
+.It Fl m
 Don't display the message of the day on login.
-.TP
-.B \-w
+.It Fl w
 Disallow root logins.
-.TP
-.B \-s
+.It Fl s
 Disable password logins.
-.TP
-.B \-g
+.It Fl g
 Disable password logins for root.
-.TP
-.B \-t
+.It Fl t
 Enable two-factor authentication. Both password login and public key authentication are
-required. Should not be used with the '-s' option.
-.TP
-.B \-j
+required. Should not be used with the
+.Fl s
+option.
+.It Fl j
 Disable local port forwarding. This includes unix stream forwards.
-.TP
-.B \-k
+.It Fl k
 Disable remote port forwarding.
-.TP
-.B \-p\fR [\fIaddress\fR:]\fIport
-Listen on specified 
-.I address
+.It Fl p Ar [address:]port
+Listen on specified
+.Ar address
 and TCP
-.I port.
+.Ar port .
 If just a port is given listen
 on all addresses.
 Up to 10 can be specified (default 22 if none specified).
-.TP
-.B \-l \fIinterface
+.It Fl l Ar interface
 Listen on the specified
-.I interface
-.TP
-.B \-i
+.Ar interface
+.It Fl i
 Service program mode.
 Use this option to run
-.B dropbear
+.Nm dropbear
 under TCP/IP servers like inetd, tcpsvd, or tcpserver.
-In program mode the \-F option is implied, and \-p options are ignored.
-.TP
-.B \-P \fIpidfile
-Specify a pidfile to create when running as a daemon. If not specified, the 
-default is /var/run/dropbear.pid
-.TP
-.B \-a
+In program mode the
+.Fl F
+option is implied, and
+.Fl p
+options are ignored.
+.It Fl P Ar pidfile
+Specify a pidfile to create when running as a daemon. If not specified, the
+default is
+.Pa /var/run/dropbear.pid
+.It Fl a
 Allow remote hosts to connect to forwarded ports.
-.TP
-.B \-W \fIwindowsize
-Specify the per-channel receive window buffer size. Increasing this 
+.It Fl W Ar windowsize
+Specify the per-channel receive window buffer size. Increasing this
 may improve network performance at the expense of memory use. Use -h to see the
 default buffer size.
-.TP
-.B \-K \fItimeout_seconds
+.It Fl K Ar timeout_seconds
 Ensure that traffic is transmitted at a certain interval in seconds. This is
 useful for working around firewalls or routers that drop connections after
 a certain period of inactivity. The trade-off is that a session may be
 closed if there is a temporary lapse of network connectivity. A setting
 of 0 disables keepalives. If no response is received for 3 consecutive keepalives the connection will be closed.
-.TP
-.B \-I \fIidle_timeout
-Disconnect the session if no traffic is transmitted or received for \fIidle_timeout\fR seconds.
-.TP
-.B \-M
+.It Fl I Ar idle_timeout
+Disconnect the session if no traffic is transmitted or received for
+.Ar idle_timeout
+seconds.
+.It Fl M
 Set maximum session duration in seconds. All sessions will close after this time.
-If a compile-time setting was set (default is none), then setting \fI-M 0\fR will disable
+If a compile-time setting was set (default is none), then setting
+.Fl M Ar 0
+will disable
 the session duration timeout.
-.TP
-.B \-z
-By default Dropbear will send network traffic with the \fBAF21\fR setting for QoS, letting network devices give it higher priority. Some devices may have problems with that, \fI-z\fR can be used to disable it.
-.TP
-.B \-T \fImax_authentication_attempts
-Set the number of authentication attempts allowed per connection. If unspecified the default is 10 (MAX_AUTH_TRIES)
-.TP
-.B \-c \fIforced_command
-Disregard the command/shell provided by the user and always run \fIforced_command\fR. This also
-overrides any authorized_keys command= option. The original command is saved in the 
-SSH_ORIGINAL_COMMAND environment variable (see below).
-
+.It Fl z
+By default Dropbear will send network traffic with the
+.Dv AF21
+setting for QoS, letting network devices give it higher priority. Some devices may have problems with that,
+.Fl z
+can be used to disable it.
+.It Fl T Ar max_authentication_attempts
+Set the number of authentication attempts allowed per connection. If unspecified the default is 10
+.Pq Dv MAX_AUTH_TRIES
+.It Fl c Ar forced_command
+Disregard the command/shell provided by the user and always run
+.Ar forced_command .
+This also
+overrides any
+.Pa authorized_keys
+.Cm command=
+option. The original command is saved in the
+.Ev SSH_ORIGINAL_COMMAND
+environment variable (see below).
+.Pp
 The forced command is started using the user's normal shell, the same as
 occurs for normal commands.
-
+.Pp
 Unix stream forwarding is disabled when a forced command is set, since that
 may allow a bypass of the forced command. Other SSH features such as TCP forwarding
-are still allowed by default - it may be desirable to disable those using \fI-j\fR or \fI-k\fR
+are still allowed by default - it may be desirable to disable those using
+.Fl j
+or
+.Fl k
 options when using forced command.
-
-.TP
-.B \-D \fIauthorized_keys_dir
-Specify the directory to use for authorized_keys files. The default is ~/.ssh , paths with
-a leading ~/ will be home directory expanded.
-
-.TP
-.B \-Q \fIalgo
+.It Fl D Ar authorized_keys_dir
+Specify the directory to use for
+.Pa authorized_keys
+files. The default is
+.Pa ~/.ssh ,
+paths with a leading
+.Pa ~/
+will be home directory expanded.
+.It Fl Q Ar algo
 Query supported algorithms. Options are kex, sig, cipher, mac, compress
-
-.TP
-.B \-V
+.It Fl V
 Print the version
-
-.SH FILES
-
-.TP
-Authorized Keys
-
-~/.ssh/authorized_keys can be set up to allow remote login with a
-Ed25519, RSA, or ECDSA key.
-The authorized_keys file and its containing ~/.ssh directory must only be
+.El
+.Sh FILES
+.Bl -tag -width Ds
+.It Authorized Keys
+.Pa ~/.ssh/authorized_keys
+can be set up to allow remote login with a
+.Dv Ed25519 ,
+.Dv RSA ,
+or
+.Dv ECDSA
+key.
+The
+.Pa authorized_keys
+file and its containing
+.Pa ~/.ssh
+directory must only be
 writable by the user, otherwise Dropbear will not allow a login using public
 key authentication.
-
-
+.Pp
 Each line is of the form
-.TP
+.Bd -literal -offset indent
 [restrictions] ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIgAsp... [comment]
-
-and can be extracted from a Dropbear private host key with "dropbearkey -y". This is the same format as used by OpenSSH, though the restrictions are a subset (keys with unknown restrictions are ignored).
+.Ed
+.Pp
+and can be extracted from a Dropbear private host key with
+.Ql dropbearkey -y .
+This is the same format as used by OpenSSH, though the restrictions are a subset (keys with unknown restrictions are ignored).
 Restrictions are comma separated, with double quotes around spaces in arguments.
 Available restrictions are:
-
-.RS
-
-.TP
-.B no-port-forwarding
+.Bl -tag -width Ds
+.It Cm no-port-forwarding
 Don't allow port forwarding for this connection, including unix streams.
-
-.TP
-.B no-agent-forwarding
+.It Cm no-agent-forwarding
 Don't allow agent forwarding for this connection
-
-.TP
-.B no-X11-forwarding
+.It Cm no-X11-forwarding
 Don't allow X11 forwarding for this connection
-
-.TP
-.B no-pty
+.It Cm no-pty
 Disable PTY allocation. Note that a user can still obtain most of the
 same functionality with other means even if no-pty is set.
-
-.TP
-.B restrict
+.It Cm restrict
 Applies all the no- restrictions listed above.
-
-.TP
-.B permitopen=\fR"\fIhost:port\fR"
+.It Cm permitopen= Ns Qo Ar host:port Qc
 Restrict local port forwarding so that connection is allowed only to the
 specified host and port. Multiple permitopen options separated by commas
-can be set in authorized_keys. Wildcard character ('*') may be used in
+can be set in
+.Pa authorized_keys .
+Wildcard character
+.Pq Ql *
+may be used in
 port specification for matching any port. Hosts must be literal domain names or
 IP addresses.
-
-.TP
-.B permitlisten=\fR"\fIport\fR"
+.It Cm permitlisten= Ns Qo Ar port Qc
 Restrict remote port forwarding listeners to the given port.
-Multiple permitlisten="port" options separated by commas
-can be set in authorized_keys.
+Multiple
+.Cm permitlisten= Ns Qo Ar port Qc
+options separated by commas
+can be set in
+.Pa authorized_keys .
 Port can be 0 to allow the
 listen port to be dynamically allocated on the server.
-
-.TP
-.B command=\fR"\fIforced_command\fR"
-Disregard the command provided by the user and always run \fIforced_command\fR.
-The -c command line option overrides this. See -c documentation for behaviour of
+.It Cm command= Ns Qo Ar forced_command Qc
+Disregard the command provided by the user and always run
+.Ar forced_command .
+The
+.Fl c
+command line option overrides this. See
+.Fl c
+documentation for behaviour of
 forced commands.
-
+.Pp
 When using
-.B command=
+.Cm command=
 it is often desirable to also use
-.B restrict
+.Cm restrict
 option to avoid other SSH features that may allow additional access.
-
-
-
-.RE
-
-.TP
-Host Key Files
-
+.El
+.It Host Key Files
 Host key files are read at startup from a standard location, by default
-/etc/dropbear/dropbear_dss_host_key, /etc/dropbear/dropbear_rsa_host_key,
-/etc/dropbear/dropbear_ecdsa_host_key and /etc/dropbear/dropbear_ed25519_host_key
-
-If the -r command line option is specified the default files are not loaded.
-Host key files are of the form generated by dropbearkey. 
-The -R option can be used to automatically generate keys
+.Pa /etc/dropbear/dropbear_dss_host_key ,
+.Pa /etc/dropbear/dropbear_rsa_host_key ,
+.Pa /etc/dropbear/dropbear_ecdsa_host_key
+and
+.Pa /etc/dropbear/dropbear_ed25519_host_key
+.Pp
+If the
+.Fl r
+command line option is specified the default files are not loaded.
+Host key files are of the form generated by
+.Xr dropbearkey 1 .
+The
+.Fl R
+option can be used to automatically generate keys
 in the default location - keys will be generated after startup when the first
-connection is established. This had the benefit that the system /dev/urandom
+connection is established. This had the benefit that the system
+.Pa /dev/urandom
 random number source has a better chance of being securely seeded.
-
-.TP
-Message Of The Day
-
-By default the file /etc/motd will be printed for any login shell (unless 
+.It Message Of The Day
+By default the file
+.Pa /etc/motd
+will be printed for any login shell (unless
 disabled at compile-time). This can also be disabled per-user
-by creating a file ~/.hushlogin .
-
-.SH ENVIRONMENT VARIABLES
-Dropbear sets the standard variables USER, LOGNAME, HOME, SHELL, PATH, and TERM.
-
-The variables below are set for sessions as appropriate. 
-
-.TP
-.B SSH_TTY
+by creating a file
+.Pa ~/.hushlogin .
+.El
+.Sh ENVIRONMENT VARIABLES
+Dropbear sets the standard variables
+.Ev USER ,
+.Ev LOGNAME ,
+.Ev HOME ,
+.Ev SHELL ,
+.Ev PATH ,
+and
+.Ev TERM .
+.Pp
+The variables below are set for sessions as appropriate.
+.Bl -tag -width Ds
+.It Ev SSH_TTY
 This is set to the allocated TTY if a PTY was used.
-
-.TP
-.B SSH_CONNECTION
-Contains "<remote_ip> <remote_port> <local_ip> <local_port>".
-
-.TP
-.B DISPLAY
+.It Ev SSH_CONNECTION
+Contains
+.Ql <remote_ip> <remote_port> <local_ip> <local_port> .
+.It Ev DISPLAY
 Set X11 forwarding is used.
-
-.TP
-.B SSH_ORIGINAL_COMMAND
-If a 'command=' authorized_keys option was used, the original command is specified
+.It Ev SSH_ORIGINAL_COMMAND
+If a
+.Cm command=
+.Pa authorized_keys
+option was used, the original command is specified
 in this variable. If a shell was requested this is set to an empty value.
-
-.TP
-.B SSH_AUTH_SOCK
+.It Ev SSH_AUTH_SOCK
 Set to a forwarded ssh-agent connection.
-
-.SH NOTES
+.El
+.Sh NOTES
 Dropbear only supports SSH protocol version 2.
-
-.SH AUTHOR
-Matt Johnston (matt@ucc.asn.au).
-.br
-Gerrit Pape (pape@smarden.org) wrote this manual page.
-.SH SEE ALSO
-dropbearkey(1), dbclient(1), dropbearconvert(1)
-.P
-https://matt.ucc.asn.au/dropbear/dropbear.html
+.Sh SEE ALSO
+.Xr dbclient 1 ,
+.Xr dropbearconvert 1 ,
+.Xr dropbearkey 1
+.Pp
+.Lk https://matt.ucc.asn.au/dropbear/dropbear.html
+.Sh AUTHORS
+.An Matt Johnston Aq Mt matt@ucc.asn.au .
+.An Gerrit Pape Aq Mt pape@smarden.org
+wrote this manual page.

--- a/manpages/dropbearconvert.1
+++ b/manpages/dropbearconvert.1
@@ -1,59 +1,69 @@
-.TH dropbearconvert 1
-.SH NAME
-dropbearconvert \- convert between Dropbear and OpenSSH private key formats
-.SH SYNOPSIS
-.B dropbearconvert
-.I input_type
-.I output_type
-.I input_file
-.I output_file
-.SH DESCRIPTION
-.B Dropbear
+.Dd February 1, 2023
+.Dt DROPBEARCONVERT 1
+.Os
+.Sh NAME
+.Nm dropbearconvert
+.Nd convert between Dropbear and OpenSSH private key formats
+.Sh SYNOPSIS
+.Nm
+.Ar input_type
+.Ar output_type
+.Ar input_file
+.Ar output_file
+.Sh DESCRIPTION
+Dropbear
 and
-.B OpenSSH
+OpenSSH
 SSH implementations have different private key formats.
-.B dropbearconvert
+.Nm dropbearconvert
 can convert between the two.
-.P
+.Pp
 Dropbear uses the same SSH public key format as OpenSSH, it can be extracted
 from a private key by using
-.B dropbearkey \-y
-.P
-Encrypted private keys are not supported, use ssh-keygen(1) to decrypt them
+.Nm dropbearkey
+.Fl y
+.Pp
+Encrypted private keys are not supported, use
+.Xr ssh-keygen 1
+to decrypt them
 first.
-.SH ARGUMENTS
-.TP
-.I input_type
+.Sh ARGUMENTS
+.Bl -tag -width Ds
+.It Ar input_type
 Either
-.I dropbear
+.Cm dropbear
 or
-.I openssh
-.TP
-.I output_type
+.Cm openssh
+.It Ar output_type
 Either
-.I dropbear
+.Cm dropbear
 or
-.I openssh
-.TP
-.I input_file
+.Cm openssh
+.It Ar input_file
 An existing Dropbear or OpenSSH private key file
-.TP
-.I output_file
-The path to write the converted private key file. For client authentication ~/.ssh/id_dropbear is loaded by default
-.SH SUPPORTED FORMATS
-.B dropbearconvert
-can read OpenSSH format files, and older PEM format files (
-.B ssh-keygen
-.I -m PEM
-).
-.B dropbearconvert
+.It Ar output_file
+The path to write the converted private key file. For client authentication
+.Pa ~/.ssh/id_dropbear
+is loaded by default
+.El
+.Sh SUPPORTED FORMATS
+.Nm dropbearconvert
+can read OpenSSH format files, and older PEM format files
+.Po
+.Nm ssh-keygen
+.Fl m Ar PEM
+.Pc .
+.Nm dropbearconvert
 will write OpenSSH format files, usable with OpenSSH 6.5 and later.
 Reading OpenSSH format DSS files or PKCS8 files is not currently supported.
-.SH EXAMPLE
- # dropbearconvert openssh dropbear ~/.ssh/id_rsa ~/.ssh/id_dropbear
-.SH AUTHOR
-Matt Johnston (matt@ucc.asn.au).
-.SH SEE ALSO
- dropbearkey(1), ssh-keygen(1)
-.P
-https://matt.ucc.asn.au/dropbear/dropbear.html
+.Sh EXAMPLES
+.Bd -literal -offset indent
+# dropbearconvert openssh dropbear ~/.ssh/id_rsa ~/.ssh/id_dropbear
+.Ed
+.Sh SEE ALSO
+.Xr dropbearkey 1 ,
+.Xr ssh-keygen 1
+.Pp
+.Lk https://matt.ucc.asn.au/dropbear/dropbear.html
+.Sh AUTHORS
+.An Matt Johnston Aq Mt matt@ucc.asn.au .

--- a/manpages/dropbearkey.1
+++ b/manpages/dropbearkey.1
@@ -1,61 +1,84 @@
-.TH dropbearkey 1
-.SH NAME
-dropbearkey \- create private keys for the use with dropbear(8) or dbclient(1)
-.SH SYNOPSIS
-.B dropbearkey
-\-t
-.I type
-\-f
-.I file
-[\-s
-.IR bits ]
-[\-y]
-.SH DESCRIPTION
-.B dropbearkey
+.Dd February 1, 2023
+.Dt DROPBEARKEY 1
+.Os
+.Sh NAME
+.Nm dropbearkey
+.Nd create private keys for the use with
+.Xr dropbear 8
+or
+.Xr dbclient 1
+.Sh SYNOPSIS
+.Nm
+.Fl t
+.Ar type
+.Fl f
+.Ar file
+.Op Fl s Ar bits
+.Op Fl y
+.Sh DESCRIPTION
+.Nm dropbearkey
 generates a
-\fIRSA\fR, \fIDSS\fR, \fIECDSA\fR, or \fIEd25519\fR
+.Dv RSA , DSS , ECDSA ,
+or
+.Dv Ed25519
 format SSH private key, and saves it to a file for the use with the
 Dropbear client or server.
-Note that 
+Note that
 some SSH implementations
-use the term "DSA" rather than "DSS", they mean the same thing.
-.SH OPTIONS
-.TP
-.B \-t \fItype
+use the term
+.Dq DSA
+rather than
+.Dq DSS ,
+they mean the same thing.
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl t Ar type
 Type of key to generate.
 Must be one of
-.I rsa
-.I ecdsa
-.I ed25519
+.Cm rsa ,
+.Cm ecdsa ,
+.Cm ed25519 ,
 or
-.IR dss .
-.TP
-.B \-f \fIfile
+.Cm dss .
+.It Fl f Ar file
 Write the secret key to the file
-\fIfile\fR. For client authentication ~/.ssh/id_dropbear is loaded by default
-.TP
-.B \-s \fIbits
+.Ar file .
+For client authentication
+.Pa ~/.ssh/id_dropbear
+is loaded by default
+.It Fl s Ar bits
 Set the key size to
-.I bits
-bits, should be multiple of 8 (optional). 
-.TP
-.B \-y
-Just print the publickey and fingerprint for the private key in \fIfile\fR.
-.SH NOTES
-The program dropbearconvert(1) can be used to convert between Dropbear and OpenSSH key formats.
-.P
-Dropbear does not support encrypted keys. 
-.SH EXAMPLE
+.Ar bits
+bits, should be multiple of 8 (optional).
+.It Fl y
+Just print the publickey and fingerprint for the private key in
+.Ar file .
+.El
+.Sh NOTES
+The program
+.Xr dropbearconvert 1
+can be used to convert between Dropbear and OpenSSH key formats.
+.Pp
+Dropbear does not support encrypted keys.
+.Sh EXAMPLES
 generate a host-key:
- # dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
-
-extract a public key suitable for authorized_keys from private key:
- # dropbearkey -y -f id_rsa | grep "^ssh-rsa " >> authorized_keys
-.SH AUTHOR
-Matt Johnston (matt@ucc.asn.au).
-.br
-Gerrit Pape (pape@smarden.org) wrote this manual page.
-.SH SEE ALSO
-dropbear(8), dbclient(1), dropbearconvert(1)
-.P
-https://matt.ucc.asn.au/dropbear/dropbear.html
+.Bd -literal -offset indent
+# dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
+.Ed
+.Pp
+extract a public key suitable for
+.Pa authorized_keys
+from private key:
+.Bd -literal -offset indent
+# dropbearkey -y -f id_rsa | grep "^ssh-rsa " >> authorized_keys
+.Ed
+.Sh SEE ALSO
+.Xr dbclient 1 ,
+.Xr dropbearconvert 1 ,
+.Xr dropbear 8
+.Pp
+.Lk https://matt.ucc.asn.au/dropbear/dropbear.html
+.Sh AUTHORS
+.An Matt Johnston Aq Mt matt@ucc.asn.au .
+.An Gerrit Pape Aq Mt pape@smarden.org
+wrote this manual page.


### PR DESCRIPTION
all 4 manpages have been re-typeset from the legacy man(7) to the mdoc(7) format. none of the manpage content has changed.

mdoc is a nicer format than man, it's semantic rather than purely presentation based, which has a number of benefits when it comes to rendering in various formats. it's also much nicer to write and i think more maintainable. mdoc is supported by mandoc, GNU roff, heirloom doctools and others. 

this also fixes one TODO in the dbclient.1 manpage relating to the formatting of the -J flag having two entries with a linebreak. 

obviously this is not a super urgent or important change. feel free to close if this change is not wanted for any reason.