### PR TITLE
replace ctype calls with locale-independent ascii helpers

### DIFF
--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -944,7 +944,7 @@ static int match_extendedopt(const char** strptr, const char *optname) {
 	int optlen = strlen(optname);
 	const char *str = *strptr;
 
-	while (isspace(*str)) {
+	while (ascii_isspace(*str)) {
 		++str;
 	}
 
@@ -954,7 +954,7 @@ static int match_extendedopt(const char** strptr, const char *optname) {
 
 	str += optlen;
 
-	while (isspace(*str) || (!seen_eq && *str == '=')) {
+	while (ascii_isspace(*str) || (!seen_eq && *str == '=')) {
 		if (*str == '=') {
 			seen_eq = 1;
 		}

--- a/src/compat.c
+++ b/src/compat.c
@@ -269,7 +269,7 @@ static char **initshells() {
 		if (*cp == '#' || *cp == '\0')
 			continue;
 		*sp++ = cp;
-		while (!isspace(*cp) && *cp != '#' && *cp != '\0')
+		while (!ascii_isspace(*cp) && *cp != '#' && *cp != '\0')
 			cp++;
 		*cp++ = '\0';
 	}

--- a/src/dbctype.h
+++ b/src/dbctype.h
@@ -1,0 +1,39 @@
+#ifndef DROPBEAR_DBCTYPE_H_
+#define DROPBEAR_DBCTYPE_H_
+
+/* Locale-independent replacements for the <ctype.h> character
+   classification functions. The standard ones have undefined behaviour
+   when passed a plain char with a value that doesn't fit in unsigned
+   char, and their results can vary with locale. Dropbear only cares
+   about ASCII ranges, so simple comparisons suffice. Bytes outside
+   0-127 never match. */
+
+static inline int ascii_isdigit(char c) {
+	return c >= '0' && c <= '9';
+}
+
+static inline int ascii_isalpha(char c) {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+static inline int ascii_isalnum(char c) {
+	return ascii_isalpha(c) || ascii_isdigit(c);
+}
+
+static inline int ascii_isspace(char c) {
+	return c == ' ' || c == '\t' || c == '\n'
+		|| c == '\v' || c == '\f' || c == '\r';
+}
+
+static inline int ascii_isprint(char c) {
+	return c >= 0x20 && c <= 0x7e;
+}
+
+static inline char ascii_tolower(char c) {
+	if (c >= 'A' && c <= 'Z') {
+		return c + ('a' - 'A');
+	}
+	return c;
+}
+
+#endif /* DROPBEAR_DBCTYPE_H_ */

--- a/src/dbctype.h
+++ b/src/dbctype.h
@@ -8,28 +8,38 @@
    about ASCII ranges, so simple comparisons suffice. Bytes outside
    0-127 never match. */
 
-static inline int ascii_isdigit(char c) {
+/* c89 has no "inline" keyword. gcc and clang accept __inline__ in
+   any mode; otherwise fall back to plain static functions. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define DBCTYPE_INLINE static inline
+#elif defined(__GNUC__)
+#define DBCTYPE_INLINE static __inline__
+#else
+#define DBCTYPE_INLINE static
+#endif
+
+DBCTYPE_INLINE int ascii_isdigit(char c) {
 	return c >= '0' && c <= '9';
 }
 
-static inline int ascii_isalpha(char c) {
+DBCTYPE_INLINE int ascii_isalpha(char c) {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }
 
-static inline int ascii_isalnum(char c) {
+DBCTYPE_INLINE int ascii_isalnum(char c) {
 	return ascii_isalpha(c) || ascii_isdigit(c);
 }
 
-static inline int ascii_isspace(char c) {
+DBCTYPE_INLINE int ascii_isspace(char c) {
 	return c == ' ' || c == '\t' || c == '\n'
 		|| c == '\v' || c == '\f' || c == '\r';
 }
 
-static inline int ascii_isprint(char c) {
+DBCTYPE_INLINE int ascii_isprint(char c) {
 	return c >= 0x20 && c <= 0x7e;
 }
 
-static inline char ascii_tolower(char c) {
+DBCTYPE_INLINE char ascii_tolower(char c) {
 	if (c >= 'A' && c <= 'Z') {
 		return c + ('a' - 'A');
 	}

--- a/src/dbutil.c
+++ b/src/dbutil.c
@@ -438,7 +438,7 @@ void printhex(const char * label, const unsigned char * buf, int len) {
 		fprintf(stderr, "  ");
 		for (i = 0; i < linelen; i++) {
 			char c = buf[j+i];
-			if (!isprint(c)) {
+			if (!ascii_isprint(c)) {
 				c = '.';
 			}
 			fputc(c, stderr);

--- a/src/includes.h
+++ b/src/includes.h
@@ -51,7 +51,6 @@
 #include <unistd.h>
 #include <syslog.h>
 #include <netdb.h>
-#include <ctype.h>
 #include <stdarg.h>
 #include <dirent.h>
 #include <time.h>
@@ -149,6 +148,7 @@
 #endif
 
 #include "compat.h"
+#include "dbctype.h"
 
 #ifndef HAVE_U_INT8_T
 typedef unsigned char u_int8_t;

--- a/src/keyimport.c
+++ b/src/keyimport.c
@@ -416,7 +416,7 @@ static struct openssh_key *load_openssh_key(const char *filename)
 				goto error;
 			}
 			*p++ = '\0';
-			while (*p && isspace((unsigned char)*p)) p++;
+			while (*p && ascii_isspace(*p)) p++;
 			if (!strcmp(buffer, "Proc-Type")) {
 				if (p[0] != '4' || p[1] != ',') {
 					errmsg = "Proc-Type is not 4 (only 4 is supported)";

--- a/src/scp.c
+++ b/src/scp.c
@@ -1211,7 +1211,7 @@ sink(int argc, char **argv, const char *src)
 		if (*cp++ != ' ')
 			SCREWUP("mode not delimited");
 
-		for (size = 0; isdigit(*cp);)
+		for (size = 0; ascii_isdigit(*cp);)
 			size = size * 10 + (*cp++ - '0');
 		if (*cp++ != ' ')
 			SCREWUP("size not delimited");
@@ -1498,7 +1498,7 @@ okname(char *cp0)
 		c = (int)*cp;
 		if (c & 0200)
 			goto bad;
-		if (!isalpha(c) && !isdigit(c)) {
+		if (!ascii_isalpha(c) && !ascii_isdigit(c)) {
 			switch (c) {
 			case '\'':
 			case '"':

--- a/src/svr-authpam.c
+++ b/src/svr-authpam.c
@@ -75,7 +75,7 @@ pamConvFunc(int num_msg,
 	/* Make the string lowercase. */
 	msg_len = strlen(compare_message);
 	for (i = 0; i < msg_len; i++) {
-		compare_message[i] = tolower(compare_message[i]);
+		compare_message[i] = ascii_tolower(compare_message[i]);
 	}
 
 	/* If the string ends with ": ", remove the space. 

--- a/src/svr-authpubkey.c
+++ b/src/svr-authpubkey.c
@@ -412,7 +412,7 @@ static int checkpubkey_line(buffer* line, int line_num, const char* filename,
 		}
 		/* We have an allowlist - authorized_keys lines can't be fully trusted,
 		some shell scripts may do unsafe things with env var values */
-		if (!(isalnum(c) || strchr(".,_-+@", c))) {
+		if (!(ascii_isalnum(c) || strchr(".,_-+@", c))) {
 			TRACE(("Not setting SSH_PUBKEYINFO, special characters"))
 			infolen = 0;
 			break;

--- a/src/svr-x11fwd.c
+++ b/src/svr-x11fwd.c
@@ -50,7 +50,7 @@ xauth_valid_string(const char *s)
 	size_t i;
 
 	for (i = 0; s[i] != '\0'; i++) {
-		if (!isalnum(s[i]) &&
+		if (!ascii_isalnum(s[i]) &&
 		    s[i] != '.' && s[i] != ':' && s[i] != '/' &&
 		    s[i] != '-' && s[i] != '_') {
 			return DROPBEAR_FAILURE;


### PR DESCRIPTION
Several ctype calls in the tree hand a plain char to isalnum, isdigit, isspace, isprint or tolower. Where char is signed, a byte with the high bit set arrives as a negative int, which is outside the [0,255] plus EOF range these functions are defined for, so the result is undefined and on some libcs reads the classification table out of bounds. Some of the inputs are remote: the x11 auth protocol and cookie a client sends in an x11-req go through xauth_valid_string, the key comment that becomes SSH_PUBKEYINFO runs through checkpubkey_line, and a remote scp server's size field is scanned by isdigit in sink().

Per review, instead of casting to unsigned char at each call site, this adds simple locale-independent replacements as static inline functions in a new dbctype.h, included from includes.h in place of ctype.h, and converts every caller (including keyimport.c and okname() in scp.c, so nothing in the tree uses ctype anymore). They just check ASCII ranges; bytes above 0x7f never match, and the results for ASCII input are unchanged.