### PR TITLE
avoid out-of-bounds read in line_abbrevname

### DIFF
--- a/src/loginrec.c
+++ b/src/loginrec.c
@@ -421,8 +421,8 @@ line_abbrevname(char *dst, const char *src, size_t dstsize)
 	len = strlen(src);
 
 	if (len > 0) {
-		if (((int)len - dstsize) > 0)
-			src +=  ((int)len - dstsize);
+		if (((int)len - (int)dstsize) > 0)
+			src +=  ((int)len - (int)dstsize);
 
 		/* note: _don't_ change this to strlcpy */
 		strncpy(dst, src, (size_t)dstsize);


### PR DESCRIPTION
line_abbrevname() takes the trailing dstsize characters of a tty name and copies them into the utmp/utmpx ut_id field. It decides how far to walk src forward with ((int)len - dstsize), but dstsize is a size_t, so that subtraction happens in unsigned arithmetic. When the abbreviated name is shorter than the destination field, len - dstsize wraps to a large unsigned value that is always greater than zero, the guard fires, and src gets advanced by that value, which in pointer terms moves src back before the start of its buffer. strncpy then copies dstsize bytes from there, reading off the front of the string and writing those stray bytes into ut_id. I noticed it comparing this file against the OpenSSH original, which casts both operands to int so the whole expression stays signed; the size_t parameter here is a local change that lost that second cast. Casting dstsize to int restores the signed comparison and offset. It shows up where sizeof(ut_id) is larger than the tty name, and an ASAN build reads a few bytes before the source buffer without the cast.