### PR TITLE
Un-deprecate two factor -t

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,8 @@ Note >> for compatibility/configuration changes
 
 - >> Two factor auth "-t" has been deprecated, it now requires
   a configuration option DEPRECATED_TWO_FACTOR.
-  Planned to be removed in future.
+  [Updated 16 July: This is no longer planned to be removed, future releases
+  will ignore DEPRECATED_TWO_FACTOR and always enable it, like previously]
 
 - Security: server: Don't allow -B (accept blank password) with
   -t (two factor auth). If run with -t and -B a user configured with a

--- a/src/default_options.h
+++ b/src/default_options.h
@@ -407,8 +407,6 @@ runtime with -M. 0 disables this feature. */
    since they don't seem to be used much. Open a github issue if you
    want to keep them.
  */
-/* Server "-t" two factor auth */
-#define DEPRECATED_TWO_FACTOR 0
 
 /* Plugins are set with configure --enable-plugin-deprecated */
 

--- a/src/svr-runopts.c
+++ b/src/svr-runopts.c
@@ -85,9 +85,7 @@ static void printhelp(const char * progname) {
 					"-s		Disable password logins\n"
 					"-g		Disable password logins for root\n"
 					"-B		Allow blank password logins\n"
-#if DEPRECATED_TWO_FACTOR
 					"-t		Enable two-factor authentication (both password and public key required)\n"
-#endif
 #endif
 					"-T		Maximum authentication tries (default %d)\n"
 #if DROPBEAR_SVR_LOCALANYFWD
@@ -346,11 +344,9 @@ void svr_getopts(int argc, char ** argv) {
 				case 'B':
 					svr_opts.allowblankpass = 1;
 					break;
-#if DEPRECATED_TWO_FACTOR
 				case 't':
 					svr_opts.multiauthmethod = 1;
 					break;
-#endif
 #else
 				case 's':
 				case 'g':


### PR DESCRIPTION
There is demand for two factor, so it'll be kept.

This partially reverts
e3e7b28c33ac ("Make -t two factor and plugins deprecated") Plugins are unchanged.

Closes #464 on github