### PR TITLE
bound openssh public key parse to its declared length

### DIFF
--- a/src/keyimport.c
+++ b/src/keyimport.c
@@ -563,6 +563,11 @@ static sign_key *openssh_read(const char *filename, const char * UNUSED(passphra
 
 		/* limit length of public key blob */
 		len = buf_getint(blobbuf);
+		if (len > blobbuf->len - blobbuf->pos) {
+			errmsg = "Error parsing OpenSSH key";
+			goto ossh_error;
+		}
+		buf_setlen(blobbuf, blobbuf->pos + len);
 
 		type = DROPBEAR_SIGNKEY_ANY;
 		if (buf_get_pub_key(blobbuf, retkey, &type)


### PR DESCRIPTION
The OpenSSH v1 private key parser reads the length prefix of the public-key section into `len`, and the comment there says it means to limit the parse to that length, but nothing actually applies it. buf_get_pub_key() runs against the whole key blob, so the public-key parse isn't confined to its declared length and can walk past the public-key field into the private-key material that follows. I noticed it while reading the block, since the "restore full length" line right after only makes sense if the length had been narrowed first. It's reachable through dropbearconvert when importing an untrusted OpenSSH key: a file whose public-key length field disagrees with the actual encoded key is accepted rather than rejected. The fix checks len against the bytes remaining and narrows blobbuf with buf_setlen before the parse, then the existing restore puts it back for the private-key half. Valid keys of every type still convert to byte-identical output, and a key with a corrupted public-key length is now turned away.