### PR TITLE
scp: fix build with gcc >= 14.x

### DIFF
--- a/src/scp.c
+++ b/src/scp.c
@@ -81,6 +81,7 @@
 #include "compat.h"
 #include "scpmisc.h"
 #include "progressmeter.h"
+#include "dbutil.h"
 
 void bwlimit(int);
 


### PR DESCRIPTION
Fixes build errors seen with gcc 14.x:
```
src/scp.c: In function ‘sink’:
src/scp.c:1214:32: error: implicit declaration of function ‘ascii_isdigit’
 [-Wimplicit-function-declaration]

src/scp.c: In function ‘okname’:
src/scp.c:1501:22: error: implicit declaration of function ‘ascii_isalpha’
 [-Wimplicit-function-declaration]
```

Patch provided by SVoxel: https://github.com/mkj/dropbear/issues/473