### PR TITLE
scp: Fix ascii_isdigit build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         include:
           - name: plain linux
             upload_sizes: 1
+            make_target: all scp SCPPROGRESS=1
 
           - name: multi binary
             multi: 1
@@ -51,6 +52,7 @@ jobs:
 
           - name: linux clang
             cc: clang
+            make_target: all scp
 
           # Some platforms only have old compilers, we try to keep
           # compatibilty. For some reason -std=c89 doesn't enforce

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
           # Check that debug code doesn't bitrot
           - name: DEBUG_TRACE
             nondefault: 1
-            configure_flags: --enable-pam
+            configure_flags: --enable-pam --enable-werror
             localoptions: |
               #define DEBUG_TRACE 5
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
         if: ${{ matrix.nondefault }}
         run: |
           # Turn on anything that's off by default. Rough but seems sufficient
-          grep ' 0$' src/default_options.h | sed 's/0$/1/' >> localoptions.h
+          grep ' 0$' src/default_options.h | grep -v DEBUG_TRACE | sed 's/0$/1/' >> localoptions.h
           # PAM clashes with password
           echo "#define DROPBEAR_SVR_PASSWORD_AUTH 0" >> localoptions.h
           # 1 second timeout is too short

--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ _COMMONOBJS=dbutil.o buffer.o dbhelpers.o \
 		atomicio.o compat.o fake-rfc2553.o \
 		ltc_prng.o ecc.o ecdsa.o sk-ecdsa.o crypto_desc.o \
 		curve25519.o ed25519.o sk-ed25519.o \
-		dbmalloc.o \
+		dbmalloc.o dbctype.o \
 		gensignkey.o gendss.o genrsa.o gened25519.o
 COMMONOBJS = $(patsubst %,$(OBJ_DIR)/%,$(_COMMONOBJS))
 
@@ -74,7 +74,7 @@ KEYOBJS = $(patsubst %,$(OBJ_DIR)/%,$(_KEYOBJS))
 _CONVERTOBJS=dropbearconvert.o keyimport.o signkey_ossh.o
 CONVERTOBJS = $(patsubst %,$(OBJ_DIR)/%,$(_CONVERTOBJS))
 
-_SCPOBJS=scp.o progressmeter.o atomicio.o scpmisc.o compat.o
+_SCPOBJS=scp.o progressmeter.o atomicio.o scpmisc.o compat.o dbctype.o
 SCPOBJS = $(patsubst %,$(OBJ_DIR)/%,$(_SCPOBJS))
 
 ifeq (@DROPBEAR_FUZZ@, 1)

--- a/src/cli-runopts.c
+++ b/src/cli-runopts.c
@@ -1138,7 +1138,7 @@ static void add_extendedopt(const char* origstr) {
 
 #if DROPBEAR_USE_SSH_CONFIG
 static void apply_config_settings(const char* cli_host_arg) {
-	char* is_multi_hop_host_target = strchr(cli_host_arg, ',');
+	const char* is_multi_hop_host_target = strchr(cli_host_arg, ',');
 	if (!is_multi_hop_host_target) {
 		char* config_path = expand_homedir_path(DROPBEAR_DEFAULT_SSH_CONFIG);
 		FILE* f;

--- a/src/dbctype.c
+++ b/src/dbctype.c
@@ -1,0 +1,36 @@
+#include "dbctype.h"
+
+/* Locale-independent replacements for the <ctype.h> character
+   classification functions. The standard ones have undefined behaviour
+   when passed a plain char with a value that doesn't fit in unsigned
+   char, and their results can vary with locale. Dropbear only cares
+   about ASCII ranges, so simple comparisons suffice. Bytes outside
+   0-127 never match. */
+
+int ascii_isdigit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+int ascii_isalpha(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+int ascii_isalnum(char c) {
+    return ascii_isalpha(c) || ascii_isdigit(c);
+}
+
+int ascii_isspace(char c) {
+    return c == ' ' || c == '\t' || c == '\n'
+        || c == '\v' || c == '\f' || c == '\r';
+}
+
+int ascii_isprint(char c) {
+    return c >= 0x20 && c <= 0x7e;
+}
+
+char ascii_tolower(char c) {
+    if (c >= 'A' && c <= 'Z') {
+        return c + ('a' - 'A');
+    }
+    return c;
+}

--- a/src/dbctype.h
+++ b/src/dbctype.h
@@ -1,0 +1,13 @@
+#ifndef DBCTYPE_H
+#define DBCTYPE_H
+
+/* Sensible ctype alternatives */
+int ascii_isdigit(char c);
+int ascii_isalpha(char c);
+int ascii_isalnum(char c);
+int ascii_isspace(char c);
+int ascii_isprint(char c);
+char ascii_tolower(char c);
+
+#endif
+

--- a/src/dbutil.c
+++ b/src/dbutil.c
@@ -879,38 +879,3 @@ void cleantext(char* dirtytext, int allow_whitespace) {
 	/* Null terminate */
 	dirtytext[j] = '\0';
 }
-
-/* Locale-independent replacements for the <ctype.h> character
-   classification functions. The standard ones have undefined behaviour
-   when passed a plain char with a value that doesn't fit in unsigned
-   char, and their results can vary with locale. Dropbear only cares
-   about ASCII ranges, so simple comparisons suffice. Bytes outside
-   0-127 never match. */
-
-int ascii_isdigit(char c) {
-	return c >= '0' && c <= '9';
-}
-
-int ascii_isalpha(char c) {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-}
-
-int ascii_isalnum(char c) {
-	return ascii_isalpha(c) || ascii_isdigit(c);
-}
-
-int ascii_isspace(char c) {
-	return c == ' ' || c == '\t' || c == '\n'
-		|| c == '\v' || c == '\f' || c == '\r';
-}
-
-int ascii_isprint(char c) {
-	return c >= 0x20 && c <= 0x7e;
-}
-
-char ascii_tolower(char c) {
-	if (c >= 'A' && c <= 'Z') {
-		return c + ('a' - 'A');
-	}
-	return c;
-}

--- a/src/dbutil.h
+++ b/src/dbutil.h
@@ -118,13 +118,4 @@ int scp_main(int argc, char ** argv);
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 
-
-/* Sensible ctype alternatives */
-int ascii_isdigit(char c);
-int ascii_isalpha(char c);
-int ascii_isalnum(char c);
-int ascii_isspace(char c);
-int ascii_isprint(char c);
-char ascii_tolower(char c);
-
 #endif /* DROPBEAR_DBUTIL_H_ */

--- a/src/includes.h
+++ b/src/includes.h
@@ -148,6 +148,7 @@
 #endif
 
 #include "compat.h"
+#include "dbctype.h"
 
 #ifndef HAVE_U_INT8_T
 typedef unsigned char u_int8_t;

--- a/src/scp.c
+++ b/src/scp.c
@@ -1027,7 +1027,10 @@ rsource(char *name, struct stat *statp)
 			run_err("%s/%s: name too long", name, dp->d_name);
 			continue;
 		}
-		(void) snprintf(path, sizeof path, "%s/%s", name, dp->d_name);
+		if (snprintf(path, sizeof path, "%s/%s", name, dp->d_name) >= (int)(sizeof path)) {
+			// Unreachable, checked above. This avoids -Wformat-truncation.
+			abort();
+		}
 		vect[0] = path;
 		source(1, vect);
 	}

--- a/src/scp.c
+++ b/src/scp.c
@@ -943,6 +943,8 @@ next:			if (fd != -1) {
 #ifdef PROGRESS_METER
 		if (showprogress)
 			start_progress_meter(curfile, stb.st_size, &statbytes);
+#else
+        (void)statbytes;
 #endif
 		/* Keep writing after an error so that we stay sync'd up. */
 		for (haderr = i = 0; i < stb.st_size; i += bp->cnt) {
@@ -1300,6 +1302,8 @@ bad:			run_err("%s: %s", np, strerror(errno));
 #ifdef PROGRESS_METER
 		if (showprogress)
 			start_progress_meter(curfile, size, &statbytes);
+#else
+        (void)statbytes;
 #endif
 		for (count = i = 0; i < size; i += 4096) {
 			amt = 4096;


### PR DESCRIPTION
Move ctype replacements to dbctype.c, include it for scp.
    
Fixes: 7af125aa4bb8 ("Move ctype replacement functions to dbutil.c")

Fixes #473 

The first commit fixes the problem, the others are adding CI for scp and other CI problems noticed in the process.