### PR TITLE
logging: add square brackets when print raw ipv6 addresses

### DIFF
--- a/src/cli-session.c
+++ b/src/cli-session.c
@@ -420,10 +420,17 @@ void cli_dropbear_exit(int exitcode, const char* format, va_list param) {
 	if (!ses.init_done) {
 		snprintf(fullmsg, sizeof(fullmsg), "Exited: %s", exitmsg);
 	} else {
-		snprintf(fullmsg, sizeof(fullmsg), 
+		if (strchr(cli_opts.remotehost, ':') != NULL) {
+			snprintf(fullmsg, sizeof(fullmsg), 
+				"Connection to %s@[%s]:%s exited: %s", 
+				cli_opts.username, cli_opts.remotehost, 
+				cli_opts.remoteport, exitmsg);
+		} else {
+			snprintf(fullmsg, sizeof(fullmsg), 
 				"Connection to %s@%s:%s exited: %s", 
 				cli_opts.username, cli_opts.remotehost, 
 				cli_opts.remoteport, exitmsg);
+		}
 	}
 
 	/* Do the cleanup first, since then the terminal will be reset */

--- a/src/svr-main.c
+++ b/src/svr-main.c
@@ -105,7 +105,12 @@ static void main_inetd() {
 	if (svr_opts.reexec_childpipe < 0) {
 		/* In case our inetd was lax in logging source addresses */
 		get_socket_address(0, NULL, NULL, &host, &port, 0);
-			dropbear_log(LOG_INFO, "Child connection from %s:%s", host, port);
+			if (strchr(host, ':') != NULL) {
+				dropbear_log(LOG_INFO, "Child connection from [%s]:%s", host, port);
+			} else {
+				dropbear_log(LOG_INFO, "Child connection from %s:%s", host, port);
+			}
+
 		m_free(host);
 		m_free(port);
 
@@ -326,7 +331,12 @@ static void main_noinetd(int argc, char ** argv, const char* multipath) {
 
 				/* child */
 				getaddrstring(&remoteaddr, NULL, &remote_port, 0);
-				dropbear_log(LOG_INFO, "Child connection from %s:%s", remote_host, remote_port);
+				if (strchr(remote_host, ':') != NULL) {
+					dropbear_log(LOG_INFO, "Child connection from [%s]:%s", remote_host, remote_port);
+				} else {
+					dropbear_log(LOG_INFO, "Child connection from %s:%s", remote_host, remote_port);
+				}
+
 				m_free(remote_host);
 				m_free(remote_port);
 

--- a/src/svr-session.c
+++ b/src/svr-session.c
@@ -121,7 +121,12 @@ void svr_session(int sock, int childpipe) {
 	get_socket_address(ses.sock_in, NULL, NULL, &host, &port, 0);
 	len = strlen(host) + strlen(port) + 2;
 	svr_ses.addrstring = m_malloc(len);
-	snprintf(svr_ses.addrstring, len, "%s:%s", host, port);
+	/* bracket is needed if it's IPv6 address */
+	if (strchr(host, ':') != NULL) {
+		snprintf(svr_ses.addrstring, len, "[%s]:%s", host, port);
+	} else {
+		snprintf(svr_ses.addrstring, len, "%s:%s", host, port);
+	}
 	m_free(host);
 	m_free(port);
 


### PR DESCRIPTION
otherwise it'll print malformed IPv6 address in log like "Connection to fe80:3221::1:32514 closed"
RFC3986 requires literal ipv6 address in hostname context need to be warped in a square brackets