### PR TITLE
client: Remove unprinted message at exit

### DIFF
--- a/src/cli-session.c
+++ b/src/cli-session.c
@@ -376,8 +376,6 @@ static void cli_finished() {
 	TRACE(("cli_finished()"))
 
 	session_cleanup();
-	fprintf(stderr, "Connection to %s@%s:%s closed.\n", cli_opts.username,
-			cli_opts.remotehost, cli_opts.remoteport);
 	exit(cli_ses.retval);
 }
 


### PR DESCRIPTION
Dropbear was intending to print
"Connection to user@host closed."
when the last channel closed, but it never was printed since stderr is already closed by session_cleanup().

Given the status quo seems OK, just remove the print.